### PR TITLE
[#15] Use direct CDROM methods (closes #15)

### DIFF
--- a/src/main/java/legend/game/SStrm.java
+++ b/src/main/java/legend/game/SStrm.java
@@ -12,6 +12,7 @@ import legend.core.memory.Value;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import static legend.core.Hardware.CDROM;
 import static legend.core.Hardware.CPU;
 import static legend.core.Hardware.DMA;
 import static legend.core.Hardware.MEMORY;
@@ -26,7 +27,6 @@ import static legend.game.Scus94491BpeSegment_8002.FUN_8002bda4;
 import static legend.game.Scus94491BpeSegment_8002.FUN_8002c150;
 import static legend.game.Scus94491BpeSegment_8002.setCdMix;
 import static legend.game.Scus94491BpeSegment_8003.ClearImage;
-import static legend.game.Scus94491BpeSegment_8003.DsControl;
 import static legend.game.Scus94491BpeSegment_8003.FUN_80030a10;
 import static legend.game.Scus94491BpeSegment_8003.FUN_80030b20;
 import static legend.game.Scus94491BpeSegment_8003.FUN_80030bb0;
@@ -337,9 +337,11 @@ public final class SStrm {
     disableCdromDmaCallbacksAndClearDataFifo();
 
     //LAB_800fbf88
-    while(!DsControl(CdlCOMMAND.PAUSE_09, 0, 0)) {
-      DebugHelper.sleep(1);
-    }
+    CDROM.sendCommand(CdlCOMMAND.PAUSE_09);
+    CDROM.acknowledgeInterrupts();
+//    while(!DsControl(CdlCOMMAND.PAUSE_09, 0, 0)) {
+//      DebugHelper.sleep(1);
+//    }
 
     removeFromLinkedList(mdecInDoubleBufferFrame0_8010f7d4.get());
     removeFromLinkedList(mdecInDoubleBufferFrame1_8010f7d8.get());

--- a/src/main/java/legend/game/SStrm.java
+++ b/src/main/java/legend/game/SStrm.java
@@ -339,9 +339,6 @@ public final class SStrm {
     //LAB_800fbf88
     CDROM.sendCommand(CdlCOMMAND.PAUSE_09);
     CDROM.acknowledgeInterrupts();
-//    while(!DsControl(CdlCOMMAND.PAUSE_09, 0, 0)) {
-//      DebugHelper.sleep(1);
-//    }
 
     removeFromLinkedList(mdecInDoubleBufferFrame0_8010f7d4.get());
     removeFromLinkedList(mdecInDoubleBufferFrame1_8010f7d8.get());

--- a/src/main/java/legend/game/Scus94491BpeSegment_8003.java
+++ b/src/main/java/legend/game/Scus94491BpeSegment_8003.java
@@ -1116,11 +1116,6 @@ public final class Scus94491BpeSegment_8003 {
     CDROM_REG0.setu(0);
 
     //LAB_80032604
-//    for(long param = 0; param < command.paramCount; param++) {
-//      CDROM_REG2.setu(MEMORY.ref(1, paramAddress).offset(param));
-//    }
-//
-//    CDROM_REG1.setu(command.command);
     final long[] params = new long[command.paramCount];
     for(int param = 0; param < command.paramCount; param++) {
       params[param] = MEMORY.ref(1, paramAddress).offset(param).get();
@@ -1301,30 +1296,18 @@ public final class Scus94491BpeSegment_8003 {
 
     CDROM.sendCommand(CdlCOMMAND.GET_STAT_01);
     CDROM.acknowledgeInterrupts();
-//    DsControl(CdlCOMMAND.GET_STAT_01, 0, 0, false);
 
     if(_80052f50.get(0x10L) == 0) {
       CDROM.sendCommand(CdlCOMMAND.GET_STAT_01);
       CDROM.acknowledgeInterrupts();
-//      DsControl(CdlCOMMAND.GET_STAT_01, 0, 0, false);
     }
 
     //LAB_80032ca4
     CDROM.sendCommand(CdlCOMMAND.INIT_0A);
     CDROM.acknowledgeInterrupts();
-//    if(DsControl(CdlCOMMAND.INIT_0A, 0, 0, false) != 0) {
-//      return -0x1L;
-//    }
 
     CDROM.sendCommand(CdlCOMMAND.DEMUTE_0C);
     CDROM.acknowledgeInterrupts();
-//    if(DsControl(CdlCOMMAND.DEMUTE_0C, 0, 0, false) != 0) {
-//      return -0x1L;
-//    }
-
-//    if(FUN_80031f44(0, 0) != SyncCode.COMPLETE) {
-//      return -0x1L;
-//    }
 
     //LAB_80032cfc
     //LAB_80032d00

--- a/src/main/java/legend/game/Scus94491BpeSegment_8003.java
+++ b/src/main/java/legend/game/Scus94491BpeSegment_8003.java
@@ -123,6 +123,7 @@ import static legend.game.Scus94491BpeSegment_8005.Vcount;
 import static legend.game.Scus94491BpeSegment_8005._80052f24;
 import static legend.game.Scus94491BpeSegment_8005._80052f50;
 import static legend.game.Scus94491BpeSegment_8005._80052f54;
+import static legend.game.Scus94491BpeSegment_8005._80052f58;
 import static legend.game.Scus94491BpeSegment_8005._80053008;
 import static legend.game.Scus94491BpeSegment_8005._80053088;
 import static legend.game.Scus94491BpeSegment_8005._80053108;
@@ -820,6 +821,15 @@ public final class Scus94491BpeSegment_8003 {
       if(errors != 0) {
         throw new RuntimeException("CDROM errors " + Long.toHexString(errors));
       }
+
+      if(_80052f50.get(0x10L) == 0) {
+        if((results[0] & 0x10L) != 0) {
+          _80052f58.addu(0x1L);
+        }
+      }
+
+      _80052f50.setu(results[0]);
+      _80052f54.setu(results[1]);
     }
 
     //LAB_80031b94


### PR DESCRIPTION
Makes a lot of the CDROM code interact directly with the CDROM emulator instead of communicating via registers. It's faster and fixes desyncs during concurrency. This should fix the fairly common crash on startup.