### PR TITLE
Fix HP in menus being out of sync from save files, mods

### DIFF
--- a/src/main/java/legend/game/SItem.java
+++ b/src/main/java/legend/game/SItem.java
@@ -1517,7 +1517,7 @@ public final class SItem {
         renderTwoDigitNumber(x + 154, y + 6, stats.level_0e.get());
         renderTwoDigitNumber(x + 112, y + 17, stats.dlevel_0f.get());
         renderThreeDigitNumber(x + 148, y + 17, stats.sp_08.get());
-        renderFourDigitNumber(x + 100, y + 28, gameState_800babc8.charData_32c.get(charIndex).hp_08.get(), stats.maxHp_66.get());
+        renderFourDigitNumber(x + 100, y + 28, stats.hp_04.get(), stats.maxHp_66.get());
         renderCharacter(x + 124, y + 28, 11);
         renderFourDigitNumber(x + 142, y + 28, stats.maxHp_66.get());
         renderThreeDigitNumber(x + 106, y + 39, stats.mp_06.get());


### PR DESCRIPTION
The PR uses stats.hp_04 instead in menu displays. stats.hp_04 is more accurate than gamestate's hp_08 for menus.

hp_08 shouldn't be used in the menu display of HP as this does not sync with external sources of information (.dsavs, mods) on initial load of the game or when fresh events are consumed between battles. Stale values will thus be shown in the menu in these situations.

Since gamestate's hp_08 syncs with hp_04 before battle begins, this should be inconsequential. However, new to the codebase so may have overlooked a sync context with this somewhere!

Note 1: If I'm not incorrect, then gamestate's hp_08 should be refactored to be used only in battle to avoid future sync issues with future mod expansion (mods can target gamestate HP or out of combat HP events specifically).

Examples:
1. HP > maxHP on .dsav Load
• HP will display as higher than maxHP

2. Previous .dsav HP value will be displayed if a mod or external resource through the game has modified HP
• HP will display a stale value and not the real value for items / beginning of battle

3. If a mod uses event.hp to set a static HP outside of battle, there are a range of fringe cases where the a stale HP value from battle or other sources may be present in the
• Replace menu
• Render character portraits of the 3 selected characters

Tested the following and received expected behaviour:
• .dsav HP > maxHP
• .dsav with event.hp set
• fresh file with event.hp set
• using healing items in menu
• equipping/unequipping armor in menu
• replacing characters

In BaseMod this can be added to test the implications.
```
@EventListener
public static void event(final CharacterStatsEvent event) {
  event.hp = 400;
  event.maxHp = 200;
}

```

Pics

![image](https://user-images.githubusercontent.com/29797557/219708165-a515c230-bb12-4469-a2f8-c172772bf2b2.png)
• HP is set to 400 by a mod
• maxHP is set to 200 by a mod
• the .dsav has pre-existing values that get displayed even though they are technically stale
• The game does not detect that HP > maxHP


![image](https://user-images.githubusercontent.com/29797557/219708917-428f571f-3c05-481a-8709-139ac4433d72.png)
• HP is set to 400 by a mod
• maxHP is set to 200 by a mod
• proper values are displayed and HP gets clamped properly