### PR TITLE
Adhering EventManager to thread-safe Singleton model

### DIFF
--- a/src/main/java/legend/game/modding/events/EventManager.java
+++ b/src/main/java/legend/game/modding/events/EventManager.java
@@ -26,7 +26,7 @@ public class EventManager {
   private final Map<Consumer<Event>, Class<?>> listeners = new HashMap<>();
   private final Set<Consumer<Event>> staleListeners = Collections.synchronizedSet(new HashSet<>());
 
-  public EventManager() {
+  private EventManager() {
     LOGGER.info("Scanning for event consumers...");
 
     final ConfigurationBuilder config = new ConfigurationBuilder()


### PR DESCRIPTION
Since the EventManager walks like a duck for the Singleton pattern with the .INSTANCE property, it may be appropriate to modify the constructor to prevent initializations of the EventManager. Don't see any indicators that the EventManager will break the Singleton pattern with future expansion.