### PR TITLE
Rename and refactor entities relating to battle preloading entities with a focus on additions

### DIFF
--- a/src/main/java/legend/game/SItem.java
+++ b/src/main/java/legend/game/SItem.java
@@ -19,7 +19,7 @@ import legend.core.memory.types.UnsignedShortRef;
 import legend.game.combat.Bttl_800c;
 import legend.game.combat.types.BattleObject27c;
 import legend.game.combat.types.BattleScriptDataBase;
-import legend.game.combat.types.BattleStruct18cb0;
+import legend.game.combat.types.BattlePreloadedEntities;
 import legend.game.combat.types.CombatantStruct1a8;
 import legend.game.inventory.WhichMenu;
 import legend.game.inventory.screens.MainMenuScreen;
@@ -59,7 +59,7 @@ import static legend.game.SMap.FUN_800e3fac;
 import static legend.game.Scus94491BpeSegment.FUN_80018e84;
 import static legend.game.Scus94491BpeSegment.FUN_800192d8;
 import static legend.game.Scus94491BpeSegment.FUN_80019470;
-import static legend.game.Scus94491BpeSegment._1f8003f4;
+import static legend.game.Scus94491BpeSegment.battlePreloadedEntities_1f8003f4;
 import static legend.game.Scus94491BpeSegment.decrementOverlayCount;
 import static legend.game.Scus94491BpeSegment.deferReallocOrFree;
 import static legend.game.Scus94491BpeSegment.displayWidth_1f8003e0;
@@ -427,7 +427,7 @@ public final class SItem {
 
   @Method(0x800fc404L)
   public static void enemyTexturesLoadedCallback(final List<FileData> files) {
-    final BattleStruct18cb0 s2 = _1f8003f4;
+    final BattlePreloadedEntities s2 = battlePreloadedEntities_1f8003f4;
 
     //LAB_800fc434
     for(int i = 0; i < combatantCount_800c66a0.get(); i++) {

--- a/src/main/java/legend/game/SItem.java
+++ b/src/main/java/legend/game/SItem.java
@@ -19,7 +19,7 @@ import legend.core.memory.types.UnsignedShortRef;
 import legend.game.combat.Bttl_800c;
 import legend.game.combat.types.BattleObject27c;
 import legend.game.combat.types.BattleScriptDataBase;
-import legend.game.combat.types.BattlePreloadedEntities;
+import legend.game.combat.types.BattlePreloadedEntities_18cb0;
 import legend.game.combat.types.CombatantStruct1a8;
 import legend.game.inventory.WhichMenu;
 import legend.game.inventory.screens.MainMenuScreen;
@@ -427,7 +427,7 @@ public final class SItem {
 
   @Method(0x800fc404L)
   public static void enemyTexturesLoadedCallback(final List<FileData> files) {
-    final BattlePreloadedEntities s2 = battlePreloadedEntities_1f8003f4;
+    final BattlePreloadedEntities_18cb0 s2 = battlePreloadedEntities_1f8003f4;
 
     //LAB_800fc434
     for(int i = 0; i < combatantCount_800c66a0.get(); i++) {

--- a/src/main/java/legend/game/Scus94491BpeSegment.java
+++ b/src/main/java/legend/game/Scus94491BpeSegment.java
@@ -34,7 +34,7 @@ import legend.game.combat.Bttl_800f;
 import legend.game.combat.SBtld;
 import legend.game.combat.SEffe;
 import legend.game.combat.types.BattleObject27c;
-import legend.game.combat.types.BattleStruct18cb0;
+import legend.game.combat.types.BattlePreloadedEntities;
 import legend.game.combat.types.StageData10;
 import legend.game.debugger.Debugger;
 import legend.game.inventory.WhichMenu;
@@ -302,7 +302,7 @@ public final class Scus94491BpeSegment {
   public static final UnsignedShortRef tmdGp0Tpage_1f8003ec = MEMORY.ref(2, 0x1f8003ecL, UnsignedShortRef::new);
   public static final UnsignedShortRef tmdGp0CommandId_1f8003ee = MEMORY.ref(2, 0x1f8003eeL, UnsignedShortRef::new);
 
-  public static BattleStruct18cb0 _1f8003f4;
+  public static BattlePreloadedEntities battlePreloadedEntities_1f8003f4;
   public static final IntRef projectionPlaneDistance_1f8003f8 = MEMORY.ref(4, 0x1f8003f8L, IntRef::new);
   public static final Value _1f8003fc = MEMORY.ref(4, 0x1f8003fcL);
 

--- a/src/main/java/legend/game/Scus94491BpeSegment.java
+++ b/src/main/java/legend/game/Scus94491BpeSegment.java
@@ -34,7 +34,7 @@ import legend.game.combat.Bttl_800f;
 import legend.game.combat.SBtld;
 import legend.game.combat.SEffe;
 import legend.game.combat.types.BattleObject27c;
-import legend.game.combat.types.BattlePreloadedEntities;
+import legend.game.combat.types.BattlePreloadedEntities_18cb0;
 import legend.game.combat.types.StageData10;
 import legend.game.debugger.Debugger;
 import legend.game.inventory.WhichMenu;
@@ -302,7 +302,7 @@ public final class Scus94491BpeSegment {
   public static final UnsignedShortRef tmdGp0Tpage_1f8003ec = MEMORY.ref(2, 0x1f8003ecL, UnsignedShortRef::new);
   public static final UnsignedShortRef tmdGp0CommandId_1f8003ee = MEMORY.ref(2, 0x1f8003eeL, UnsignedShortRef::new);
 
-  public static BattlePreloadedEntities battlePreloadedEntities_1f8003f4;
+  public static BattlePreloadedEntities_18cb0 battlePreloadedEntities_1f8003f4;
   public static final IntRef projectionPlaneDistance_1f8003f8 = MEMORY.ref(4, 0x1f8003f8L, IntRef::new);
   public static final Value _1f8003fc = MEMORY.ref(4, 0x1f8003fcL);
 

--- a/src/main/java/legend/game/Scus94491BpeSegment_8004.java
+++ b/src/main/java/legend/game/Scus94491BpeSegment_8004.java
@@ -755,7 +755,7 @@ public final class Scus94491BpeSegment_8004 {
    *   <li>{@link Scus94491BpeSegment#FUN_80018998}</li>
    *   <li>{@link Scus94491BpeSegment#waitForFilesToLoad}</li>
    *   <li>{@link Scus94491BpeSegment#FUN_80018998}</li>
-   *   <li>{@link Bttl_800c#battleInitiateAndPreload}</li>
+   *   <li>{@link Bttl_800c#battleInitiateAndPreload_800c772c}</li>
    *   <li>{@link Bttl_800c#deferAllocateEnemyBattleObjects()}</li>
    *   <li>{@link Scus94491BpeSegment#waitForFilesToLoad}</li>
    *   <li>{@link Bttl_800c#deferAllocatePlayerBattleObjects()}</li>

--- a/src/main/java/legend/game/Scus94491BpeSegment_8004.java
+++ b/src/main/java/legend/game/Scus94491BpeSegment_8004.java
@@ -755,7 +755,7 @@ public final class Scus94491BpeSegment_8004 {
    *   <li>{@link Scus94491BpeSegment#FUN_80018998}</li>
    *   <li>{@link Scus94491BpeSegment#waitForFilesToLoad}</li>
    *   <li>{@link Scus94491BpeSegment#FUN_80018998}</li>
-   *   <li>{@link Bttl_800c#FUN_800c772c}</li>
+   *   <li>{@link Bttl_800c#battleInitiateAndPreload}</li>
    *   <li>{@link Bttl_800c#deferAllocateEnemyBattleObjects()}</li>
    *   <li>{@link Scus94491BpeSegment#waitForFilesToLoad}</li>
    *   <li>{@link Bttl_800c#deferAllocatePlayerBattleObjects()}</li>

--- a/src/main/java/legend/game/combat/Bttl_800c.java
+++ b/src/main/java/legend/game/combat/Bttl_800c.java
@@ -42,7 +42,7 @@ import legend.game.combat.types.BattleObject27c;
 import legend.game.combat.types.BattleScriptDataBase;
 import legend.game.combat.types.BattleStage;
 import legend.game.combat.types.BattleStageDarkening1800;
-import legend.game.combat.types.BattleStruct18cb0;
+import legend.game.combat.types.BattlePreloadedEntities;
 import legend.game.combat.types.BattleStruct24_2;
 import legend.game.combat.types.BattleStruct3c;
 import legend.game.combat.types.BattleStructEf4;
@@ -93,7 +93,7 @@ import static legend.core.GameEngine.SCRIPTS;
 import static legend.game.Scus94491BpeSegment.FUN_80013404;
 import static legend.game.Scus94491BpeSegment.FUN_8001ad18;
 import static legend.game.Scus94491BpeSegment.FUN_8001af00;
-import static legend.game.Scus94491BpeSegment._1f8003f4;
+import static legend.game.Scus94491BpeSegment.battlePreloadedEntities_1f8003f4;
 import static legend.game.Scus94491BpeSegment.btldLoadEncounterSoundEffectsAndMusic;
 import static legend.game.Scus94491BpeSegment.centreScreenX_1f8003dc;
 import static legend.game.Scus94491BpeSegment.centreScreenY_1f8003de;
@@ -801,11 +801,11 @@ public final class Bttl_800c {
   @Method(0x800c7488L)
   public static int getHitMultiplier(final int charSlot, final int hitNum, final int a2) {
     if((_8006e398.charBobjIndices_e40[charSlot].storage_44[7] & 0x2) != 0) { // Is dragoon
-      return _1f8003f4._38[charSlot + 3].hits_00[hitNum]._00[a2];
+      return battlePreloadedEntities_1f8003f4.additionHits[charSlot + 3].hits[hitNum].hitProperty[a2];
     }
 
     //LAB_800c74fc
-    return _1f8003f4._38[charSlot].hits_00[hitNum]._00[a2];
+    return battlePreloadedEntities_1f8003f4.additionHits[charSlot].hits[hitNum].hitProperty[a2];
   }
 
   @Method(0x800c7524L)
@@ -877,7 +877,7 @@ public final class Bttl_800c {
   }
 
   @Method(0x800c772cL)
-  public static void FUN_800c772c() {
+  public static void battleInitiateAndPreload() {
     FUN_800c8e48();
 
     _800bc94c.setu(0x1L);
@@ -897,7 +897,7 @@ public final class Bttl_800c {
 
     _8006e398.morphMode_ee4 = gameState_800babc8.morphMode_4e2.get();
 
-    loadSupportOverlay(1, SBtld::FUN_80109250);
+    loadSupportOverlay(1, SBtld::battlePrepareSelectedAdditionHitProperties);
 
     //LAB_800c7830
     for(int i = 0; i < 12; i++) {
@@ -1286,22 +1286,22 @@ public final class Bttl_800c {
 
   @Method(0x800c8624L)
   public static void FUN_800c8624() {
-    _1f8003f4 = new BattleStruct18cb0();
+    battlePreloadedEntities_1f8003f4 = new BattlePreloadedEntities();
     _8006e398 = new BattleStructEf4();
     targetBobjs_800c71f0 = new ScriptState[][] {_8006e398.charBobjIndices_e40, _8006e398.enemyBobjIndices_ebc, _8006e398.bobjIndices_e78};
   }
 
   @Method(0x800c8748L)
   public static void FUN_800c8748() {
-    if(_1f8003f4.stageTmdMrg_63c != null) {
-      free(_1f8003f4.stageTmdMrg_63c.getAddress());
+    if(battlePreloadedEntities_1f8003f4.stageTmdMrg_63c != null) {
+      free(battlePreloadedEntities_1f8003f4.stageTmdMrg_63c.getAddress());
     }
 
-    if(_1f8003f4.stageMcq_9cb0 != null) {
-      free(_1f8003f4.stageMcq_9cb0.getAddress());
+    if(battlePreloadedEntities_1f8003f4.stageMcq_9cb0 != null) {
+      free(battlePreloadedEntities_1f8003f4.stageMcq_9cb0.getAddress());
     }
 
-    _1f8003f4 = null;
+    battlePreloadedEntities_1f8003f4 = null;
     _8006e398 = null;
     targetBobjs_800c71f0 = null;
   }
@@ -1314,14 +1314,14 @@ public final class Bttl_800c {
       _800c6754.set(1);
       stageHasModel_800c66b8.set(true);
 
-      if(_1f8003f4.stageTmdMrg_63c != null) {
-        free(_1f8003f4.stageTmdMrg_63c.getAddress());
+      if(battlePreloadedEntities_1f8003f4.stageTmdMrg_63c != null) {
+        free(battlePreloadedEntities_1f8003f4.stageTmdMrg_63c.getAddress());
       }
 
-      _1f8003f4.stageTmdMrg_63c = MrgFile.alloc(files);
+      battlePreloadedEntities_1f8003f4.stageTmdMrg_63c = MrgFile.alloc(files);
 
-      final BattleStage stage = _1f8003f4.stage_963c;
-      loadStageTmd(stage, _1f8003f4.stageTmdMrg_63c.getFile(0, CContainer::new), _1f8003f4.stageTmdMrg_63c.getFile(1, TmdAnimationFile::new));
+      final BattleStage stage = battlePreloadedEntities_1f8003f4.stage_963c;
+      loadStageTmd(stage, battlePreloadedEntities_1f8003f4.stageTmdMrg_63c.getFile(0, CContainer::new), battlePreloadedEntities_1f8003f4.stageTmdMrg_63c.getFile(1, TmdAnimationFile::new));
       stage.coord2_558.coord.transfer.set(0, 0, 0);
       stage.param_5a8.rotate.set((short)0, (short)0x400, (short)0);
     }
@@ -1340,34 +1340,34 @@ public final class Bttl_800c {
     } else {
       _800c6774.add(_800c676c.get());
       _800c6778.add(_800c6770.get());
-      final int x0 = ((int)_800c66cc.getSigned() * FUN_800dd118() / 0x1000 + _800c6774.get()) % _1f8003f4.stageMcq_9cb0.screenWidth_14.get() - centreScreenX_1f8003dc.get();
-      final int x1 = x0 - _1f8003f4.stageMcq_9cb0.screenWidth_14.get();
-      final int x2 = x0 + _1f8003f4.stageMcq_9cb0.screenWidth_14.get();
+      final int x0 = ((int)_800c66cc.getSigned() * FUN_800dd118() / 0x1000 + _800c6774.get()) % battlePreloadedEntities_1f8003f4.stageMcq_9cb0.screenWidth_14.get() - centreScreenX_1f8003dc.get();
+      final int x1 = x0 - battlePreloadedEntities_1f8003f4.stageMcq_9cb0.screenWidth_14.get();
+      final int x2 = x0 + battlePreloadedEntities_1f8003f4.stageMcq_9cb0.screenWidth_14.get();
       int y = _800c6778.get() - (FUN_800dd0d4() + 0x800 & 0xfff) + 0x760 - centreScreenY_1f8003de.get();
-      renderMcq(_1f8003f4.stageMcq_9cb0, 320, 0, x0, y, orderingTableSize_1f8003c8.get() - 2, mcqColour_800fa6dc.get());
-      renderMcq(_1f8003f4.stageMcq_9cb0, 320, 0, x1, y, orderingTableSize_1f8003c8.get() - 2, mcqColour_800fa6dc.get());
+      renderMcq(battlePreloadedEntities_1f8003f4.stageMcq_9cb0, 320, 0, x0, y, orderingTableSize_1f8003c8.get() - 2, mcqColour_800fa6dc.get());
+      renderMcq(battlePreloadedEntities_1f8003f4.stageMcq_9cb0, 320, 0, x1, y, orderingTableSize_1f8003c8.get() - 2, mcqColour_800fa6dc.get());
 
       if(centreScreenX_1f8003dc.get() >= x2) {
-        renderMcq(_1f8003f4.stageMcq_9cb0, 320, 0, x2, y, orderingTableSize_1f8003c8.get() - 2, mcqColour_800fa6dc.get());
+        renderMcq(battlePreloadedEntities_1f8003f4.stageMcq_9cb0, 320, 0, x2, y, orderingTableSize_1f8003c8.get() - 2, mcqColour_800fa6dc.get());
       }
 
       //LAB_800c89d4
-      if(_1f8003f4.stageMcq_9cb0.magic_00.get() != McqHeader.MAGIC_1) {
+      if(battlePreloadedEntities_1f8003f4.stageMcq_9cb0.magic_00.get() != McqHeader.MAGIC_1) {
         //LAB_800c89f8
-        y += _1f8003f4.stageMcq_9cb0.screenOffsetY_2a.get();
+        y += battlePreloadedEntities_1f8003f4.stageMcq_9cb0.screenOffsetY_2a.get();
       }
 
       //LAB_800c8a04
       final int colour = mcqColour_800fa6dc.get();
       if(y >= -centreScreenY_1f8003de.get()) {
-        _8007a3a8.set(_1f8003f4.stageMcq_9cb0._18.get() * colour / 0x80);
-        _800bb104.set(_1f8003f4.stageMcq_9cb0._19.get() * colour / 0x80);
-        _800babc0.set(_1f8003f4.stageMcq_9cb0._1a.get() * colour / 0x80);
+        _8007a3a8.set(battlePreloadedEntities_1f8003f4.stageMcq_9cb0._18.get() * colour / 0x80);
+        _800bb104.set(battlePreloadedEntities_1f8003f4.stageMcq_9cb0._19.get() * colour / 0x80);
+        _800babc0.set(battlePreloadedEntities_1f8003f4.stageMcq_9cb0._1a.get() * colour / 0x80);
       } else {
         //LAB_800c8a74
-        _8007a3a8.set(_1f8003f4.stageMcq_9cb0._20.get() * colour / 0x80);
-        _800bb104.set(_1f8003f4.stageMcq_9cb0._21.get() * colour / 0x80);
-        _800babc0.set(_1f8003f4.stageMcq_9cb0._22.get() * colour / 0x80);
+        _8007a3a8.set(battlePreloadedEntities_1f8003f4.stageMcq_9cb0._20.get() * colour / 0x80);
+        _800bb104.set(battlePreloadedEntities_1f8003f4.stageMcq_9cb0._21.get() * colour / 0x80);
+        _800babc0.set(battlePreloadedEntities_1f8003f4.stageMcq_9cb0._22.get() * colour / 0x80);
       }
     }
 
@@ -1378,8 +1378,8 @@ public final class Bttl_800c {
   public static void loadStage(final int stage) {
     loadDrgnDir(0, 2497 + stage, files -> {
       if(files.get(0).real()) {
-        if(_1f8003f4.stageMcq_9cb0 != null) {
-          free(_1f8003f4.stageMcq_9cb0.getAddress());
+        if(battlePreloadedEntities_1f8003f4.stageMcq_9cb0 != null) {
+          free(battlePreloadedEntities_1f8003f4.stageMcq_9cb0.getAddress());
         }
 
         final McqHeader mcq = MEMORY.ref(4, mallocTail(files.get(0).size()), McqHeader::new);
@@ -1421,8 +1421,8 @@ public final class Bttl_800c {
   @Method(0x800c8cf0L)
   public static void FUN_800c8cf0() {
     if(stageHasModel_800c66b8.get() && _800c6754.get() != 0 && (_800bc960.get() & 0x20) != 0) {
-      FUN_800ec744(_1f8003f4.stage_963c);
-      FUN_800ec51c(_1f8003f4.stage_963c);
+      FUN_800ec744(battlePreloadedEntities_1f8003f4.stage_963c);
+      FUN_800ec51c(battlePreloadedEntities_1f8003f4.stage_963c);
     }
 
     //LAB_800c8d50
@@ -1443,7 +1443,7 @@ public final class Bttl_800c {
     loadMcq(mcq, x, 0);
 
     //LAB_800c8dc0
-    _1f8003f4.stageMcq_9cb0 = mcq;
+    battlePreloadedEntities_1f8003f4.stageMcq_9cb0 = mcq;
 
     _800c66d4.setu(0x1L);
     _800c66cc.setu((0x400L / mcq.screenWidth_14.get() + 0x1L) * mcq.screenWidth_14.get());
@@ -1452,7 +1452,7 @@ public final class Bttl_800c {
   @Method(0x800c8e48L)
   public static void FUN_800c8e48() {
     if(_800c66d4.get() != 0 && (_800bc960.get() & 0x80) == 0) {
-      final RECT sp0x10 = new RECT((short)512, (short)0, _1f8003f4.stageMcq_9cb0.vramWidth_08.get(), (short)256);
+      final RECT sp0x10 = new RECT((short)512, (short)0, battlePreloadedEntities_1f8003f4.stageMcq_9cb0.vramWidth_08.get(), (short)256);
       MoveImage(sp0x10, 320, 0);
       _800c6764.set(1);
       _800bc960.or(0x80);
@@ -1697,7 +1697,7 @@ public final class Bttl_800c {
 
     final TmdAnimationFile anim = FUN_800ca31c(combatantIndex, 0);
     if((s0.flags_19e & 0x4) != 0) {
-      final BattleStruct18cb0.Rendering1298 a0_0 = _1f8003f4._9ce8[s0.charSlot_19c];
+      final BattlePreloadedEntities.Rendering1298 a0_0 = battlePreloadedEntities_1f8003f4._9ce8[s0.charSlot_19c];
 
       model.dobj2ArrPtr_00 = a0_0.dobj2s_00;
       model.coord2ArrPtr_04 = a0_0.coord2s_230;

--- a/src/main/java/legend/game/combat/Bttl_800c.java
+++ b/src/main/java/legend/game/combat/Bttl_800c.java
@@ -39,10 +39,11 @@ import legend.game.combat.types.BattleDisplayStats144;
 import legend.game.combat.types.BattleLightStruct64;
 import legend.game.combat.types.BattleMenuStruct58;
 import legend.game.combat.types.BattleObject27c;
+import legend.game.combat.types.BattlePreloadedEntities_18cb0;
 import legend.game.combat.types.BattleScriptDataBase;
 import legend.game.combat.types.BattleStage;
 import legend.game.combat.types.BattleStageDarkening1800;
-import legend.game.combat.types.BattlePreloadedEntities;
+import legend.game.combat.types.BattlePreloadedEntities_18cb0;
 import legend.game.combat.types.BattleStruct24_2;
 import legend.game.combat.types.BattleStruct3c;
 import legend.game.combat.types.BattleStructEf4;
@@ -801,11 +802,11 @@ public final class Bttl_800c {
   @Method(0x800c7488L)
   public static int getHitMultiplier(final int charSlot, final int hitNum, final int a2) {
     if((_8006e398.charBobjIndices_e40[charSlot].storage_44[7] & 0x2) != 0) { // Is dragoon
-      return battlePreloadedEntities_1f8003f4.additionHits[charSlot + 3].hits[hitNum].hitProperty[a2];
+      return battlePreloadedEntities_1f8003f4.additionHits_38[charSlot + 3].hits_00[hitNum].hitProperty_00[a2];
     }
 
     //LAB_800c74fc
-    return battlePreloadedEntities_1f8003f4.additionHits[charSlot].hits[hitNum].hitProperty[a2];
+    return battlePreloadedEntities_1f8003f4.additionHits_38[charSlot].hits_00[hitNum].hitProperty_00[a2];
   }
 
   @Method(0x800c7524L)
@@ -877,7 +878,7 @@ public final class Bttl_800c {
   }
 
   @Method(0x800c772cL)
-  public static void battleInitiateAndPreload() {
+  public static void battleInitiateAndPreload_800c772c() {
     FUN_800c8e48();
 
     _800bc94c.setu(0x1L);
@@ -897,7 +898,7 @@ public final class Bttl_800c {
 
     _8006e398.morphMode_ee4 = gameState_800babc8.morphMode_4e2.get();
 
-    loadSupportOverlay(1, SBtld::battlePrepareSelectedAdditionHitProperties);
+    loadSupportOverlay(1, SBtld::battlePrepareSelectedAdditionHitProperties_80109250);
 
     //LAB_800c7830
     for(int i = 0; i < 12; i++) {
@@ -1286,7 +1287,7 @@ public final class Bttl_800c {
 
   @Method(0x800c8624L)
   public static void FUN_800c8624() {
-    battlePreloadedEntities_1f8003f4 = new BattlePreloadedEntities();
+    battlePreloadedEntities_1f8003f4 = new BattlePreloadedEntities_18cb0();
     _8006e398 = new BattleStructEf4();
     targetBobjs_800c71f0 = new ScriptState[][] {_8006e398.charBobjIndices_e40, _8006e398.enemyBobjIndices_ebc, _8006e398.bobjIndices_e78};
   }
@@ -1697,7 +1698,7 @@ public final class Bttl_800c {
 
     final TmdAnimationFile anim = FUN_800ca31c(combatantIndex, 0);
     if((s0.flags_19e & 0x4) != 0) {
-      final BattlePreloadedEntities.Rendering1298 a0_0 = battlePreloadedEntities_1f8003f4._9ce8[s0.charSlot_19c];
+      final BattlePreloadedEntities_18cb0.Rendering1298 a0_0 = battlePreloadedEntities_1f8003f4._9ce8[s0.charSlot_19c];
 
       model.dobj2ArrPtr_00 = a0_0.dobj2s_00;
       model.coord2ArrPtr_04 = a0_0.coord2s_230;

--- a/src/main/java/legend/game/combat/Bttl_800e.java
+++ b/src/main/java/legend/game/combat/Bttl_800e.java
@@ -97,7 +97,7 @@ import static legend.core.GameEngine.SCRIPTS;
 import static legend.core.MemoryHelper.getMethodAddress;
 import static legend.game.SItem.loadCharacterStats;
 import static legend.game.Scus94491BpeSegment.FUN_8001d068;
-import static legend.game.Scus94491BpeSegment._1f8003f4;
+import static legend.game.Scus94491BpeSegment.battlePreloadedEntities_1f8003f4;
 import static legend.game.Scus94491BpeSegment.centreScreenX_1f8003dc;
 import static legend.game.Scus94491BpeSegment.centreScreenY_1f8003de;
 import static legend.game.Scus94491BpeSegment.decrementOverlayCount;
@@ -2298,7 +2298,7 @@ public final class Bttl_800e {
     s0.model_134 = s0.model_10;
 
     if((s2 & 0xff00_0000) == 0x700_0000) {
-      FUN_800e9ae4(s0.model_10, _1f8003f4.stage_963c);
+      FUN_800e9ae4(s0.model_10, battlePreloadedEntities_1f8003f4.stage_963c);
     } else {
       //LAB_800ea030
       FUN_800e9db4(s0.model_10, ((BattleObject27c)scriptStatePtrArr_800bc1c0[s2].innerStruct_00).model_148);

--- a/src/main/java/legend/game/combat/SBtld.java
+++ b/src/main/java/legend/game/combat/SBtld.java
@@ -7,7 +7,7 @@ import legend.core.memory.types.Pointer;
 import legend.game.combat.deff.DeffManager7cc;
 import legend.game.combat.types.BattleObject27c;
 import legend.game.combat.types.BattleScriptDataBase;
-import legend.game.combat.types.BattlePreloadedEntities;
+import legend.game.combat.types.BattlePreloadedEntities_18cb0;
 import legend.game.combat.types.CombatantStruct1a8;
 import legend.game.combat.types.EncounterData38;
 import legend.game.combat.types.EnemyRewards08;
@@ -117,11 +117,11 @@ public class SBtld {
   }
 
   @Method(0x80109250L)
-  public static void battlePrepareSelectedAdditionHitProperties() {
+  public static void battlePrepareSelectedAdditionHitProperties_80109250() {
     //LAB_801092a0
     for(int charSlot = 0; charSlot < 3; charSlot++) {
-      final BattlePreloadedEntities.AdditionHits activeAdditionHits = battlePreloadedEntities_1f8003f4.additionHits[charSlot];
-      final BattlePreloadedEntities.AdditionHits activeDragoonAdditionHits = battlePreloadedEntities_1f8003f4.additionHits[charSlot + 3];
+      final BattlePreloadedEntities_18cb0.AdditionHits_100 activeAdditionHits = battlePreloadedEntities_1f8003f4.additionHits_38[charSlot];
+      final BattlePreloadedEntities_18cb0.AdditionHits_100 activeDragoonAdditionHits = battlePreloadedEntities_1f8003f4.additionHits_38[charSlot + 3];
       final int charIndex = gameState_800babc8.charIndex_88.get(charSlot).get();
 
       if(charIndex >= 0) {
@@ -141,11 +141,11 @@ public class SBtld {
 
         //LAB_80109310
         if(activeAdditionIndex < 0) {
-          activeAdditionHits.hits[0].hitProperty[15] = 0;
+          activeAdditionHits.hits_00[0].hitProperty_00[15] = 0;
         } else {
           //LAB_80109320
-          battleMapSelectedAdditionHitProperties(_8010e658.offset(activeAdditionIndex * 0x80L).getAddress(), activeAdditionHits);
-          battleMapSelectedAdditionHitProperties(_8010e658.offset(activeDragoonAdditionIndex * 0x80L).getAddress(), activeDragoonAdditionHits);
+          battleMapSelectedAdditionHitProperties_80109454(_8010e658.offset(activeAdditionIndex * 0x80L).getAddress(), activeAdditionHits);
+          battleMapSelectedAdditionHitProperties_80109454(_8010e658.offset(activeDragoonAdditionIndex * 0x80L).getAddress(), activeDragoonAdditionHits);
         }
       }
 
@@ -158,36 +158,36 @@ public class SBtld {
   }
 
   @Method(0x80109454L)
-  public static void battleMapSelectedAdditionHitProperties(final long mainAdditionHitsTablePtr, final BattlePreloadedEntities.AdditionHits activeAdditionHits) {
+  public static void battleMapSelectedAdditionHitProperties_80109454(final long mainAdditionHitsTablePtr, final BattlePreloadedEntities_18cb0.AdditionHits_100 activeAdditionHits) {
     //LAB_80109460
-    for(int i = 0; i < activeAdditionHits.hits.length; i++) {
-      final BattlePreloadedEntities.AdditionHitProperties hitIndex = activeAdditionHits.hits[i];
+    for(int i = 0; i < activeAdditionHits.hits_00.length; i++) {
+      final BattlePreloadedEntities_18cb0.AdditionHitProperties_20 hitIndex = activeAdditionHits.hits_00[i];
       final long additionHitRefCounter = mainAdditionHitsTablePtr + i * 0x10L;
 
-      for(int j = 0; j < hitIndex.hitProperty.length; j++) {
+      for(int j = 0; j < hitIndex.hitProperty_00.length; j++) {
         if(j > 5 && j < 9) {
-          hitIndex.hitProperty[j] = (short)MEMORY.ref(1, additionHitRefCounter).offset(j).getSigned();
+          hitIndex.hitProperty_00[j] = (short)MEMORY.ref(1, additionHitRefCounter).offset(j).getSigned();
           continue;
         }
-        hitIndex.hitProperty[j] = (short)MEMORY.ref(1, additionHitRefCounter).offset(j).get();
+        hitIndex.hitProperty_00[j] = (short)MEMORY.ref(1, additionHitRefCounter).offset(j).get();
       }
     }
 
     final AdditionHitEvent event = EventManager.INSTANCE.postEvent(new AdditionHitEvent(activeAdditionHits));
 
-    for(int i = 0; i < activeAdditionHits.hits.length; i++) {
-      final BattlePreloadedEntities.AdditionHitProperties hitIndex = event.addition.hits[i];
+    for(int i = 0; i < activeAdditionHits.hits_00.length; i++) {
+      final BattlePreloadedEntities_18cb0.AdditionHitProperties_20 hitIndex = event.addition.hits_00[i];
       final long additionHitRefCounter = mainAdditionHitsTablePtr + i * 0x10L;
 
-      for(int j = 0; j < hitIndex.hitProperty.length; j++) {
-        MEMORY.ref(1, additionHitRefCounter).offset(j).set(hitIndex.hitProperty[j]);
+      for(int j = 0; j < hitIndex.hitProperty_00.length; j++) {
+        MEMORY.ref(1, additionHitRefCounter).offset(j).set(hitIndex.hitProperty_00[j]);
       }
     }
   }
 
   @Method(0x8010955cL)
   public static void allocateEnemyBattleObjects() {
-    final BattlePreloadedEntities fp = battlePreloadedEntities_1f8003f4;
+    final BattlePreloadedEntities_18cb0 fp = battlePreloadedEntities_1f8003f4;
 
     //LAB_801095a0
     for(int i = 0; i < 3; i++) {

--- a/src/main/java/legend/game/combat/SBtld.java
+++ b/src/main/java/legend/game/combat/SBtld.java
@@ -163,44 +163,21 @@ public class SBtld {
     for(int i = 0; i < 8; i++) {
       final BattlePreloadedEntities.AdditionHitProperties hitIndex = activeAdditionHits.hits[i];
       final long additionHitRefCounter = mainAdditionHitsTablePtr + i * 0x10L;
-      hitIndex.hitProperty[ 0] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0x0L).get();
-      hitIndex.hitProperty[ 1] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0x1L).get();
-      hitIndex.hitProperty[ 2] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0x2L).get();
-      hitIndex.hitProperty[ 3] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0x3L).get();
-      hitIndex.hitProperty[ 4] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0x4L).get();
-      hitIndex.hitProperty[ 5] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0x5L).get();
-      hitIndex.hitProperty[ 6] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0x6L).getSigned();
-      hitIndex.hitProperty[ 7] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0x7L).getSigned();
-      hitIndex.hitProperty[ 8] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0x8L).getSigned();
-      hitIndex.hitProperty[ 9] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0x9L).get();
-      hitIndex.hitProperty[10] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0xaL).get();
-      hitIndex.hitProperty[11] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0xbL).get();
-      hitIndex.hitProperty[12] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0xcL).get();
-      hitIndex.hitProperty[13] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0xdL).get();
-      hitIndex.hitProperty[14] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0xeL).get();
-      hitIndex.hitProperty[15] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0xfL).get();
+
+      for(int j=0;j<16;j++) {
+        hitIndex.hitProperty[j] = (short)MEMORY.ref(1, additionHitRefCounter).offset(j).get();
+      }
     }
 
     final AdditionHitEvent event = EventManager.INSTANCE.postEvent(new AdditionHitEvent(activeAdditionHits));
+
     for(int i = 0; i < 8; i++) {
-      final BattlePreloadedEntities.AdditionHitProperties additionHitProperties = event.addition.hits[i];
+      final BattlePreloadedEntities.AdditionHitProperties hitIndex = event.addition.hits[i];
       final long additionHitRefCounter = mainAdditionHitsTablePtr + i * 0x10L;
-      MEMORY.ref(1, additionHitRefCounter).offset(0x0L).set(additionHitProperties.hitProperty[0]);
-      MEMORY.ref(1, additionHitRefCounter).offset(0x1L).set(additionHitProperties.hitProperty[1]);
-      MEMORY.ref(1, additionHitRefCounter).offset(0x2L).set(additionHitProperties.hitProperty[2]);
-      MEMORY.ref(1, additionHitRefCounter).offset(0x3L).set(additionHitProperties.hitProperty[3]);
-      MEMORY.ref(1, additionHitRefCounter).offset(0x4L).set(additionHitProperties.hitProperty[4]);
-      MEMORY.ref(1, additionHitRefCounter).offset(0x5L).set(additionHitProperties.hitProperty[5]);
-      MEMORY.ref(1, additionHitRefCounter).offset(0x6L).set(additionHitProperties.hitProperty[6]);
-      MEMORY.ref(1, additionHitRefCounter).offset(0x7L).set(additionHitProperties.hitProperty[7]);
-      MEMORY.ref(1, additionHitRefCounter).offset(0x8L).set(additionHitProperties.hitProperty[8]);
-      MEMORY.ref(1, additionHitRefCounter).offset(0x9L).set(additionHitProperties.hitProperty[9]);
-      MEMORY.ref(1, additionHitRefCounter).offset(0xaL).set(additionHitProperties.hitProperty[10]);
-      MEMORY.ref(1, additionHitRefCounter).offset(0xbL).set(additionHitProperties.hitProperty[11]);
-      MEMORY.ref(1, additionHitRefCounter).offset(0xcL).set(additionHitProperties.hitProperty[12]);
-      MEMORY.ref(1, additionHitRefCounter).offset(0xdL).set(additionHitProperties.hitProperty[13]);
-      MEMORY.ref(1, additionHitRefCounter).offset(0xeL).set(additionHitProperties.hitProperty[14]);
-      MEMORY.ref(1, additionHitRefCounter).offset(0xfL).set(additionHitProperties.hitProperty[15]);
+
+      for(int j=0;j<16;j++) {
+        MEMORY.ref(1, additionHitRefCounter).offset(j).set(hitIndex.hitProperty[j]);
+      }
     }
   }
 

--- a/src/main/java/legend/game/combat/SBtld.java
+++ b/src/main/java/legend/game/combat/SBtld.java
@@ -7,7 +7,7 @@ import legend.core.memory.types.Pointer;
 import legend.game.combat.deff.DeffManager7cc;
 import legend.game.combat.types.BattleObject27c;
 import legend.game.combat.types.BattleScriptDataBase;
-import legend.game.combat.types.BattleStruct18cb0;
+import legend.game.combat.types.BattlePreloadedEntities;
 import legend.game.combat.types.CombatantStruct1a8;
 import legend.game.combat.types.EncounterData38;
 import legend.game.combat.types.EnemyRewards08;
@@ -27,7 +27,7 @@ import java.nio.ByteOrder;
 
 import static legend.core.GameEngine.MEMORY;
 import static legend.core.GameEngine.SCRIPTS;
-import static legend.game.Scus94491BpeSegment._1f8003f4;
+import static legend.game.Scus94491BpeSegment.battlePreloadedEntities_1f8003f4;
 import static legend.game.Scus94491BpeSegment.decrementOverlayCount;
 import static legend.game.Scus94491BpeSegment.loadDrgnFile;
 import static legend.game.Scus94491BpeSegment.loadFile;
@@ -117,96 +117,96 @@ public class SBtld {
   }
 
   @Method(0x80109250L)
-  public static void FUN_80109250() {
+  public static void battlePrepareSelectedAdditionHitProperties() {
     //LAB_801092a0
     for(int charSlot = 0; charSlot < 3; charSlot++) {
-      final BattleStruct18cb0.AdditionStruct100 character = _1f8003f4._38[charSlot];
-      final BattleStruct18cb0.AdditionStruct100 dragoon = _1f8003f4._38[charSlot + 3];
+      final BattlePreloadedEntities.AdditionHits activeAdditionHits = battlePreloadedEntities_1f8003f4.additionHits[charSlot];
+      final BattlePreloadedEntities.AdditionHits activeDragoonAdditionHits = battlePreloadedEntities_1f8003f4.additionHits[charSlot + 3];
       final int charIndex = gameState_800babc8.charIndex_88.get(charSlot).get();
 
       if(charIndex >= 0) {
-        int addition = gameState_800babc8.charData_32c.get(charIndex).selectedAddition_19.get();
+        int activeAdditionIndex = gameState_800babc8.charData_32c.get(charIndex).selectedAddition_19.get();
         if(charIndex == 5) {
-          addition = addition + 28;
+          activeAdditionIndex = activeAdditionIndex + 28;
         }
 
         //LAB_801092dc
-        final long s0;
+        final long activeDragoonAdditionIndex;
         if(charIndex != 0 || (gameState_800babc8.dragoonSpirits_19c.get(0).get() & 0xff) >>> 7 == 0) {
           //LAB_80109308
-          s0 = _801134e8.offset(charIndex * 0x2L).getSigned();
+          activeDragoonAdditionIndex = _801134e8.offset(charIndex * 0x2L).getSigned();
         } else {
-          s0 = _801134e8.offset(0x12L).getSigned();
+          activeDragoonAdditionIndex = _801134e8.offset(0x12L).getSigned();
         }
 
         //LAB_80109310
-        if(addition < 0) {
-          character.hits_00[0]._00[15] = 0;
+        if(activeAdditionIndex < 0) {
+          activeAdditionHits.hits[0].hitProperty[15] = 0;
         } else {
           //LAB_80109320
-          FUN_80109454(_8010e658.offset(addition * 0x80L).getAddress(), character);
-          FUN_80109454(_8010e658.offset(s0 * 0x80L).getAddress(), dragoon);
+          battleMapSelectedAdditionHitProperties(_8010e658.offset(activeAdditionIndex * 0x80L).getAddress(), activeAdditionHits);
+          battleMapSelectedAdditionHitProperties(_8010e658.offset(activeDragoonAdditionIndex * 0x80L).getAddress(), activeDragoonAdditionHits);
         }
       }
 
       //LAB_80109340
     }
 
-    loadFile("encounters", file -> _1f8003f4.encounterData_00 = new EncounterData38(file.getBytes(), encounterId_800bb0f8.get() * 0x38));
+    loadFile("encounters", file -> battlePreloadedEntities_1f8003f4.encounterData_00 = new EncounterData38(file.getBytes(), encounterId_800bb0f8.get() * 0x38));
 
     decrementOverlayCount();
   }
 
   @Method(0x80109454L)
-  public static void FUN_80109454(final long a3, final BattleStruct18cb0.AdditionStruct100 a1) {
+  public static void battleMapSelectedAdditionHitProperties(final long mainAdditionHitsTablePtr, final BattlePreloadedEntities.AdditionHits activeAdditionHits) {
     //LAB_80109460
     for(int i = 0; i < 8; i++) {
-      final BattleStruct18cb0.AdditionHitStruct20 a0 = a1.hits_00[i];
-      final long v1 = a3 + i * 0x10L;
-      a0._00[ 0] = (short)MEMORY.ref(1, v1).offset(0x0L).get();
-      a0._00[ 1] = (short)MEMORY.ref(1, v1).offset(0x1L).get();
-      a0._00[ 2] = (short)MEMORY.ref(1, v1).offset(0x2L).get();
-      a0._00[ 3] = (short)MEMORY.ref(1, v1).offset(0x3L).get();
-      a0._00[ 4] = (short)MEMORY.ref(1, v1).offset(0x4L).get();
-      a0._00[ 5] = (short)MEMORY.ref(1, v1).offset(0x5L).get();
-      a0._00[ 6] = (short)MEMORY.ref(1, v1).offset(0x6L).getSigned();
-      a0._00[ 7] = (short)MEMORY.ref(1, v1).offset(0x7L).getSigned();
-      a0._00[ 8] = (short)MEMORY.ref(1, v1).offset(0x8L).getSigned();
-      a0._00[ 9] = (short)MEMORY.ref(1, v1).offset(0x9L).get();
-      a0._00[10] = (short)MEMORY.ref(1, v1).offset(0xaL).get();
-      a0._00[11] = (short)MEMORY.ref(1, v1).offset(0xbL).get();
-      a0._00[12] = (short)MEMORY.ref(1, v1).offset(0xcL).get();
-      a0._00[13] = (short)MEMORY.ref(1, v1).offset(0xdL).get();
-      a0._00[14] = (short)MEMORY.ref(1, v1).offset(0xeL).get();
-      a0._00[15] = (short)MEMORY.ref(1, v1).offset(0xfL).get();
+      final BattlePreloadedEntities.AdditionHitProperties hitIndex = activeAdditionHits.hits[i];
+      final long additionHitRefCounter = mainAdditionHitsTablePtr + i * 0x10L;
+      hitIndex.hitProperty[ 0] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0x0L).get();
+      hitIndex.hitProperty[ 1] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0x1L).get();
+      hitIndex.hitProperty[ 2] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0x2L).get();
+      hitIndex.hitProperty[ 3] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0x3L).get();
+      hitIndex.hitProperty[ 4] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0x4L).get();
+      hitIndex.hitProperty[ 5] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0x5L).get();
+      hitIndex.hitProperty[ 6] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0x6L).getSigned();
+      hitIndex.hitProperty[ 7] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0x7L).getSigned();
+      hitIndex.hitProperty[ 8] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0x8L).getSigned();
+      hitIndex.hitProperty[ 9] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0x9L).get();
+      hitIndex.hitProperty[10] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0xaL).get();
+      hitIndex.hitProperty[11] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0xbL).get();
+      hitIndex.hitProperty[12] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0xcL).get();
+      hitIndex.hitProperty[13] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0xdL).get();
+      hitIndex.hitProperty[14] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0xeL).get();
+      hitIndex.hitProperty[15] = (short)MEMORY.ref(1, additionHitRefCounter).offset(0xfL).get();
     }
 
-    final AdditionHitEvent event = EventManager.INSTANCE.postEvent(new AdditionHitEvent(a1));
+    final AdditionHitEvent event = EventManager.INSTANCE.postEvent(new AdditionHitEvent(activeAdditionHits));
     for(int i = 0; i < 8; i++) {
-      final BattleStruct18cb0.AdditionHitStruct20 a0 = event.addition.hits_00[i];
-      final long v1 = a3 + i * 0x10L;
-      MEMORY.ref(1, v1).offset(0x0L).set(a0._00[0]);
-      MEMORY.ref(1, v1).offset(0x1L).set(a0._00[1]);
-      MEMORY.ref(1, v1).offset(0x2L).set(a0._00[2]);
-      MEMORY.ref(1, v1).offset(0x3L).set(a0._00[3]);
-      MEMORY.ref(1, v1).offset(0x4L).set(a0._00[4]);
-      MEMORY.ref(1, v1).offset(0x5L).set(a0._00[5]);
-      MEMORY.ref(1, v1).offset(0x6L).set(a0._00[6]);
-      MEMORY.ref(1, v1).offset(0x7L).set(a0._00[7]);
-      MEMORY.ref(1, v1).offset(0x8L).set(a0._00[8]);
-      MEMORY.ref(1, v1).offset(0x9L).set(a0._00[9]);
-      MEMORY.ref(1, v1).offset(0xaL).set(a0._00[10]);
-      MEMORY.ref(1, v1).offset(0xbL).set(a0._00[11]);
-      MEMORY.ref(1, v1).offset(0xcL).set(a0._00[12]);
-      MEMORY.ref(1, v1).offset(0xdL).set(a0._00[13]);
-      MEMORY.ref(1, v1).offset(0xeL).set(a0._00[14]);
-      MEMORY.ref(1, v1).offset(0xfL).set(a0._00[15]);
+      final BattlePreloadedEntities.AdditionHitProperties additionHitProperties = event.addition.hits[i];
+      final long additionHitRefCounter = mainAdditionHitsTablePtr + i * 0x10L;
+      MEMORY.ref(1, additionHitRefCounter).offset(0x0L).set(additionHitProperties.hitProperty[0]);
+      MEMORY.ref(1, additionHitRefCounter).offset(0x1L).set(additionHitProperties.hitProperty[1]);
+      MEMORY.ref(1, additionHitRefCounter).offset(0x2L).set(additionHitProperties.hitProperty[2]);
+      MEMORY.ref(1, additionHitRefCounter).offset(0x3L).set(additionHitProperties.hitProperty[3]);
+      MEMORY.ref(1, additionHitRefCounter).offset(0x4L).set(additionHitProperties.hitProperty[4]);
+      MEMORY.ref(1, additionHitRefCounter).offset(0x5L).set(additionHitProperties.hitProperty[5]);
+      MEMORY.ref(1, additionHitRefCounter).offset(0x6L).set(additionHitProperties.hitProperty[6]);
+      MEMORY.ref(1, additionHitRefCounter).offset(0x7L).set(additionHitProperties.hitProperty[7]);
+      MEMORY.ref(1, additionHitRefCounter).offset(0x8L).set(additionHitProperties.hitProperty[8]);
+      MEMORY.ref(1, additionHitRefCounter).offset(0x9L).set(additionHitProperties.hitProperty[9]);
+      MEMORY.ref(1, additionHitRefCounter).offset(0xaL).set(additionHitProperties.hitProperty[10]);
+      MEMORY.ref(1, additionHitRefCounter).offset(0xbL).set(additionHitProperties.hitProperty[11]);
+      MEMORY.ref(1, additionHitRefCounter).offset(0xcL).set(additionHitProperties.hitProperty[12]);
+      MEMORY.ref(1, additionHitRefCounter).offset(0xdL).set(additionHitProperties.hitProperty[13]);
+      MEMORY.ref(1, additionHitRefCounter).offset(0xeL).set(additionHitProperties.hitProperty[14]);
+      MEMORY.ref(1, additionHitRefCounter).offset(0xfL).set(additionHitProperties.hitProperty[15]);
     }
   }
 
   @Method(0x8010955cL)
   public static void allocateEnemyBattleObjects() {
-    final BattleStruct18cb0 fp = _1f8003f4;
+    final BattlePreloadedEntities fp = battlePreloadedEntities_1f8003f4;
 
     //LAB_801095a0
     for(int i = 0; i < 3; i++) {

--- a/src/main/java/legend/game/combat/SBtld.java
+++ b/src/main/java/legend/game/combat/SBtld.java
@@ -160,22 +160,22 @@ public class SBtld {
   @Method(0x80109454L)
   public static void battleMapSelectedAdditionHitProperties(final long mainAdditionHitsTablePtr, final BattlePreloadedEntities.AdditionHits activeAdditionHits) {
     //LAB_80109460
-    for(int i = 0; i < 8; i++) {
+    for(int i = 0; i < activeAdditionHits.hits.length; i++) {
       final BattlePreloadedEntities.AdditionHitProperties hitIndex = activeAdditionHits.hits[i];
       final long additionHitRefCounter = mainAdditionHitsTablePtr + i * 0x10L;
 
-      for(int j=0;j<16;j++) {
+      for(int j = 0; j < hitIndex.hitProperty.length; j++) {
         hitIndex.hitProperty[j] = (short)MEMORY.ref(1, additionHitRefCounter).offset(j).get();
       }
     }
 
     final AdditionHitEvent event = EventManager.INSTANCE.postEvent(new AdditionHitEvent(activeAdditionHits));
 
-    for(int i = 0; i < 8; i++) {
+    for(int i = 0; i < activeAdditionHits.hits.length; i++) {
       final BattlePreloadedEntities.AdditionHitProperties hitIndex = event.addition.hits[i];
       final long additionHitRefCounter = mainAdditionHitsTablePtr + i * 0x10L;
 
-      for(int j=0;j<16;j++) {
+      for(int j = 0; j < hitIndex.hitProperty.length; j++) {
         MEMORY.ref(1, additionHitRefCounter).offset(j).set(hitIndex.hitProperty[j]);
       }
     }

--- a/src/main/java/legend/game/combat/SBtld.java
+++ b/src/main/java/legend/game/combat/SBtld.java
@@ -165,6 +165,10 @@ public class SBtld {
       final long additionHitRefCounter = mainAdditionHitsTablePtr + i * 0x10L;
 
       for(int j = 0; j < hitIndex.hitProperty.length; j++) {
+        if(j > 5 && j < 9) {
+          hitIndex.hitProperty[j] = (short)MEMORY.ref(1, additionHitRefCounter).offset(j).getSigned();
+          continue;
+        }
         hitIndex.hitProperty[j] = (short)MEMORY.ref(1, additionHitRefCounter).offset(j).get();
       }
     }

--- a/src/main/java/legend/game/combat/SEffe.java
+++ b/src/main/java/legend/game/combat/SEffe.java
@@ -109,7 +109,7 @@ import static legend.core.MemoryHelper.getMethodAddress;
 import static legend.game.Scus94491BpeSegment.FUN_80018a5c;
 import static legend.game.Scus94491BpeSegment.FUN_80018d60;
 import static legend.game.Scus94491BpeSegment.FUN_80018dec;
-import static legend.game.Scus94491BpeSegment._1f8003f4;
+import static legend.game.Scus94491BpeSegment.battlePreloadedEntities_1f8003f4;
 import static legend.game.Scus94491BpeSegment.displayHeight_1f8003e4;
 import static legend.game.Scus94491BpeSegment.displayWidth_1f8003e0;
 import static legend.game.Scus94491BpeSegment.free;
@@ -9893,7 +9893,7 @@ public final class SEffe {
       //LAB_801185b0
     } else if(type == 0x700_0000) {
       //LAB_80118610
-      s0.tmd_08.set(_1f8003f4.stage_963c.dobj2s_00[objIndex].tmd_08);
+      s0.tmd_08.set(battlePreloadedEntities_1f8003f4.stage_963c.dobj2s_00[objIndex].tmd_08);
     } else {
       //LAB_80118634
       final BattleScriptDataBase a0_0 = (BattleScriptDataBase)scriptStatePtrArr_800bc1c0[flags].innerStruct_00;

--- a/src/main/java/legend/game/combat/types/BattlePreloadedEntities.java
+++ b/src/main/java/legend/game/combat/types/BattlePreloadedEntities.java
@@ -9,10 +9,10 @@ import legend.game.types.MrgFile;
 import java.util.Arrays;
 
 /** 0x18cb0 bytes */
-public class BattleStruct18cb0 {
+public class BattlePreloadedEntities {
   public EncounterData38 encounterData_00;
   /** 3 slots for chars, 3 slots for dragoons */
-  public final AdditionStruct100[] _38 = new AdditionStruct100[0x100];
+  public final AdditionHits[] additionHits = new AdditionHits[0x100];
   /** This reference is only valid while it's loading */
   public MrgFile stageMrg_638;
   public MrgFile stageTmdMrg_63c;
@@ -22,21 +22,21 @@ public class BattleStruct18cb0 {
 
   public final Rendering1298[] _9ce8 = new Rendering1298[3];
 
-  public BattleStruct18cb0() {
-    Arrays.setAll(this._38, i -> new AdditionStruct100());
+  public BattlePreloadedEntities() {
+    Arrays.setAll(this.additionHits, i -> new AdditionHits());
     Arrays.setAll(this._9ce8, i -> new Rendering1298());
   }
 
-  public static class AdditionStruct100 {
-    public final AdditionHitStruct20[] hits_00 = new AdditionHitStruct20[8];
+  public static class AdditionHits {
+    public final AdditionHitProperties[] hits = new AdditionHitProperties[8];
 
-    public AdditionStruct100() {
-      Arrays.setAll(this.hits_00, i -> new AdditionHitStruct20());
+    public AdditionHits() {
+      Arrays.setAll(this.hits, i -> new AdditionHitProperties());
     }
   }
 
-  public static class AdditionHitStruct20 {
-    public final short[] _00 = new short[16];
+  public static class AdditionHitProperties {
+    public final short[] hitProperty = new short[16];
   }
 
   public static class Rendering1298 {

--- a/src/main/java/legend/game/combat/types/BattlePreloadedEntities_18cb0.java
+++ b/src/main/java/legend/game/combat/types/BattlePreloadedEntities_18cb0.java
@@ -9,10 +9,10 @@ import legend.game.types.MrgFile;
 import java.util.Arrays;
 
 /** 0x18cb0 bytes */
-public class BattlePreloadedEntities {
+public class BattlePreloadedEntities_18cb0 {
   public EncounterData38 encounterData_00;
   /** 3 slots for chars, 3 slots for dragoons */
-  public final AdditionHits[] additionHits = new AdditionHits[0x100];
+  public final AdditionHits_100[] additionHits_38 = new AdditionHits_100[0x100];
   /** This reference is only valid while it's loading */
   public MrgFile stageMrg_638;
   public MrgFile stageTmdMrg_63c;
@@ -22,21 +22,21 @@ public class BattlePreloadedEntities {
 
   public final Rendering1298[] _9ce8 = new Rendering1298[3];
 
-  public BattlePreloadedEntities() {
-    Arrays.setAll(this.additionHits, i -> new AdditionHits());
+  public BattlePreloadedEntities_18cb0() {
+    Arrays.setAll(this.additionHits_38, i -> new AdditionHits_100());
     Arrays.setAll(this._9ce8, i -> new Rendering1298());
   }
 
-  public static class AdditionHits {
-    public final AdditionHitProperties[] hits = new AdditionHitProperties[8];
+  public static class AdditionHits_100 {
+    public final AdditionHitProperties_20[] hits_00 = new AdditionHitProperties_20[8];
 
-    public AdditionHits() {
-      Arrays.setAll(this.hits, i -> new AdditionHitProperties());
+    public AdditionHits_100() {
+      Arrays.setAll(this.hits_00, i -> new AdditionHitProperties_20());
     }
   }
 
-  public static class AdditionHitProperties {
-    public final short[] hitProperty = new short[16];
+  public static class AdditionHitProperties_20 {
+    public final short[] hitProperty_00 = new short[16];
   }
 
   public static class Rendering1298 {

--- a/src/main/java/legend/game/modding/events/characters/AdditionHitEvent.java
+++ b/src/main/java/legend/game/modding/events/characters/AdditionHitEvent.java
@@ -1,12 +1,12 @@
 package legend.game.modding.events.characters;
 
-import legend.game.combat.types.BattlePreloadedEntities;
+import legend.game.combat.types.BattlePreloadedEntities_18cb0;
 import legend.game.modding.events.Event;
 
 public class AdditionHitEvent extends Event {
-  public final BattlePreloadedEntities.AdditionHits addition;
+  public final BattlePreloadedEntities_18cb0.AdditionHits_100 addition;
 
-  public AdditionHitEvent(final BattlePreloadedEntities.AdditionHits addition) {
+  public AdditionHitEvent(final BattlePreloadedEntities_18cb0.AdditionHits_100 addition) {
     this.addition = addition;
   }
 }

--- a/src/main/java/legend/game/modding/events/characters/AdditionHitEvent.java
+++ b/src/main/java/legend/game/modding/events/characters/AdditionHitEvent.java
@@ -1,12 +1,12 @@
 package legend.game.modding.events.characters;
 
-import legend.game.combat.types.BattleStruct18cb0;
+import legend.game.combat.types.BattlePreloadedEntities;
 import legend.game.modding.events.Event;
 
 public class AdditionHitEvent extends Event {
-  public final BattleStruct18cb0.AdditionStruct100 addition;
+  public final BattlePreloadedEntities.AdditionHits addition;
 
-  public AdditionHitEvent(final BattleStruct18cb0.AdditionStruct100 addition) {
+  public AdditionHitEvent(final BattlePreloadedEntities.AdditionHits addition) {
     this.addition = addition;
   }
 }


### PR DESCRIPTION
## Explanation
Deduced the classes pertaining to battle preloading and initialization and provided them with related names.
Refactored battleMapSelectedAdditionHitProperties to be more readable and extensible for future edits.
Tried to stay inline with the current naming schemes present.

## Discussion

### BattlePreloadedEntities
BattlePreloadedEntities was the best name I could come up with for this class. We have a lot of miscellaneous collections of data present. From testing, it seems everything in this grouping is preloaded before the battle screen updates. Which is inline with the parent callers both initializing the battle and also beginning to load (see preload) assets and scripts. Thus, the name is implying that this is a collection of entities that can and must be preloaded before the battle screen updates. For this, it seems like an apt name.

Wasn't sure if it was apart of the scheme to keep the _1f8003f4 suffix to battlePreloadedEntites_1f8003f4.

## Tested on main
• All additions, complete and incomplete
• Swapping additions out between battles
• Swapping characters out
• Adjusted hit property parameters to ensure they are set, get and retrieved in both data structures through the event system

