### PR TITLE
List Menu Dual Highlight Bug Fix + Shop Screen Sell DRG Alignment Fix

### DIFF
--- a/src/main/java/legend/game/inventory/screens/ItemListScreen.java
+++ b/src/main/java/legend/game/inventory/screens/ItemListScreen.java
@@ -46,13 +46,11 @@ public class ItemListScreen extends MenuScreen {
   private double scrollAccumulator;
   private final Runnable unload;
 
-  private int selectedSlotEquipment;
-  private int selectedSlotItem;
+  private int selectedSlot;
   private int slotScrollEquipment;
   private int slotScrollItem;
   private int equippedItemsCount;
-  private Renderable58 equipmentHighlight;
-  private Renderable58 itemHighlight;
+  private Renderable58 highlight;
   private Renderable58 _800bdb9c;
   private Renderable58 _800bdba0;
   private int mouseX;
@@ -80,15 +78,13 @@ public class ItemListScreen extends MenuScreen {
         deallocateRenderables(0xff);
         renderGlyphs(goodsGlyphs_801141c4, 0, 0);
         recalcInventory();
-        this.selectedSlotEquipment = 0;
-        this.selectedSlotItem = 0;
+        this.selectedSlot = 0;
         this.slotScrollEquipment = 0;
         this.slotScrollItem = 0;
-        this.currentItemId = 0xff;
-        this.equipmentHighlight = allocateUiElement(0x76, 0x76, FUN_800fc824(0), FUN_800fc814(this.selectedSlotEquipment) + 32);
-        FUN_80104b60(this.equipmentHighlight);
-        this.itemHighlight = allocateUiElement(0x76, 0x76, FUN_800fc824(1), FUN_800fc814(this.selectedSlotItem) + 32);
-        FUN_80104b60(this.itemHighlight);
+        this.setCurrent(gameState_800babc8.equipment_1e8, this.equipment, 0);
+
+        this.highlight = allocateUiElement(0x76, 0x76, FUN_800fc824(0), FUN_800fc814(this.selectedSlot) + 32);
+        FUN_80104b60(this.highlight);
         this.equippedItemsCount = FUN_80104738(this.equipment, this.items, 0x1L);
         this.renderItemList(this.slotScrollEquipment, this.slotScrollItem, 0xff, 0xff);
         this.loadingStage++;
@@ -104,7 +100,7 @@ public class ItemListScreen extends MenuScreen {
             if(this.slotScrollEquipment > 0) {
               playSound(1);
               this.slotScrollEquipment--;
-              this.setCurrent(gameState_800babc8.equipment_1e8, this.equipment, this.slotScrollEquipment + this.selectedSlotEquipment);
+              this.setCurrent(gameState_800babc8.equipment_1e8, this.equipment, this.slotScrollEquipment + this.selectedSlot);
             }
           }
 
@@ -112,7 +108,7 @@ public class ItemListScreen extends MenuScreen {
             if(this.slotScrollItem > 0) {
               playSound(1);
               this.slotScrollItem--;
-              this.setCurrent(gameState_800babc8.items_2e9, this.items, this.slotScrollItem + this.selectedSlotItem);
+              this.setCurrent(gameState_800babc8.items_2e9, this.items, this.slotScrollItem + this.selectedSlot);
             }
           }
         }
@@ -124,7 +120,7 @@ public class ItemListScreen extends MenuScreen {
             if(this.slotScrollEquipment < gameState_800babc8.equipmentCount_1e4.get() + (int)this.equippedItemsCount - 7) {
               playSound(1);
               this.slotScrollEquipment++;
-              this.setCurrent(gameState_800babc8.equipment_1e8, this.equipment, this.slotScrollEquipment + this.selectedSlotEquipment);
+              this.setCurrent(gameState_800babc8.equipment_1e8, this.equipment, this.slotScrollEquipment + this.selectedSlot);
             }
           }
 
@@ -132,10 +128,12 @@ public class ItemListScreen extends MenuScreen {
             if(this.slotScrollItem < gameState_800babc8.itemCount_1e6.get() - 7) {
               playSound(1);
               this.slotScrollItem++;
-              this.setCurrent(gameState_800babc8.items_2e9, this.items, this.slotScrollItem + this.selectedSlotItem);
+              this.setCurrent(gameState_800babc8.items_2e9, this.items, this.slotScrollItem + this.selectedSlot);
             }
           }
         }
+
+
       }
 
       // Fade out
@@ -150,6 +148,30 @@ public class ItemListScreen extends MenuScreen {
         this.unload.run();
       }
     }
+  }
+
+  private void handleVerticalInput(final boolean isScrollingUp)
+  {
+    if(this.leftSide) {
+      if(isScrollingUp ? this.selectedSlot > 0 : this.selectedSlot < 6) {
+        playSound(1);
+        this.selectedSlot += isScrollingUp ? -1 : 1;
+      } else if(isScrollingUp ? this.slotScrollEquipment > 0 : this.slotScrollEquipment < (gameState_800babc8.equipmentCount_1e4.get() + (int)this.equippedItemsCount - 7)) {
+        playSound(1);
+        this.slotScrollEquipment += isScrollingUp ? -1 : 1;
+      }
+      this.setCurrent(gameState_800babc8.equipment_1e8, this.equipment, this.slotScrollEquipment + this.selectedSlot);
+    } else {
+      if(isScrollingUp ? this.selectedSlot > 0 : this.selectedSlot < 6) {
+        playSound(1);
+        this.selectedSlot += isScrollingUp ? -1 : 1;
+      } else if(isScrollingUp ? this.slotScrollItem > 0 : this.slotScrollItem < (gameState_800babc8.itemCount_1e6.get() - 7)) {
+        playSound(1);
+        this.slotScrollItem += isScrollingUp ? -1 : 1;
+      }
+      this.setCurrent(gameState_800babc8.items_2e9, this.items, this.slotScrollItem + this.selectedSlot);
+    }
+    this.highlight.y_44 = FUN_800fc814(this.selectedSlot) + 32;
   }
 
   private void setCurrent(final ArrayRef<UnsignedByteRef> list, final List<MenuItemStruct04> display, final int index) {
@@ -198,20 +220,20 @@ public class ItemListScreen extends MenuScreen {
 
     if(this.loadingStage == 1) {
       for(int i = 0; i < Math.min(7, gameState_800babc8.equipmentCount_1e4.get() - this.slotScrollEquipment); i++) {
-        if(this.selectedSlotEquipment != i && MathHelper.inBox(x, y, 8, 31 + FUN_800fc814(i), 174, 17)) {
+        if(this.selectedSlot != i && MathHelper.inBox(x, y, 8, 31 + FUN_800fc814(i), 174, 17)) {
           playSound(1);
-          this.selectedSlotEquipment = i;
-          this.equipmentHighlight.y_44 = FUN_800fc814(i) + 32;
-          this.setCurrent(gameState_800babc8.equipment_1e8, this.equipment, this.slotScrollEquipment + this.selectedSlotEquipment);
+          this.selectedSlot = i;
+//          this.equipmentHighlight.y_44 = FUN_800fc814(i) + 32;
+          this.setCurrent(gameState_800babc8.equipment_1e8, this.equipment, this.slotScrollEquipment + this.selectedSlot);
         }
       }
 
       for(int i = 0; i < Math.min(7, gameState_800babc8.itemCount_1e6.get() - this.slotScrollItem); i++) {
-        if(this.selectedSlotItem != i && MathHelper.inBox(x, y, 186, 31 + FUN_800fc814(i), 174, 17)) {
+        if(this.selectedSlot != i && MathHelper.inBox(x, y, 186, 31 + FUN_800fc814(i), 174, 17)) {
           playSound(1);
-          this.selectedSlotItem = i;
-          this.itemHighlight.y_44 = FUN_800fc814(i) + 32;
-          this.setCurrent(gameState_800babc8.items_2e9, this.items, this.slotScrollItem + this.selectedSlotItem);
+          this.selectedSlot = i;
+//          this.itemHighlight.y_44 = FUN_800fc814(i) + 32;
+          this.setCurrent(gameState_800babc8.items_2e9, this.items, this.slotScrollItem + this.selectedSlot);
         }
       }
     }
@@ -227,9 +249,9 @@ public class ItemListScreen extends MenuScreen {
       for(int i = 0; i < Math.min(7, gameState_800babc8.equipmentCount_1e4.get() - this.slotScrollEquipment); i++) {
         if(MathHelper.inBox(x, y, 8, 31 + FUN_800fc814(i), 174, 17)) {
           playSound(1);
-          this.selectedSlotEquipment = i;
-          this.equipmentHighlight.y_44 = FUN_800fc814(i) + 32;
-          this.setCurrent(gameState_800babc8.equipment_1e8, this.equipment, this.slotScrollEquipment + this.selectedSlotEquipment);
+          this.selectedSlot = i;
+//          this.equipmentHighlight.y_44 = FUN_800fc814(i) + 32;
+          this.setCurrent(gameState_800babc8.equipment_1e8, this.equipment, this.slotScrollEquipment + this.selectedSlot);
 
           if((this.currentDisplayList.get(this.currentIndex).flags_02 & 0x2000) != 0) {
             playSound(40);
@@ -243,9 +265,9 @@ public class ItemListScreen extends MenuScreen {
       for(int i = 0; i < Math.min(7, gameState_800babc8.itemCount_1e6.get() - this.slotScrollItem); i++) {
         if(MathHelper.inBox(x, y, 186, 31 + FUN_800fc814(i), 174, 17)) {
           playSound(1);
-          this.selectedSlotItem = i;
-          this.itemHighlight.y_44 = FUN_800fc814(i) + 32;
-          this.setCurrent(gameState_800babc8.items_2e9, this.items, this.slotScrollItem + this.selectedSlotItem);
+          this.selectedSlot = i;
+//          this.itemHighlight.y_44 = FUN_800fc814(i) + 32;
+          this.setCurrent(gameState_800babc8.items_2e9, this.items, this.slotScrollItem + this.selectedSlot);
 
           if((this.currentDisplayList.get(this.currentIndex).flags_02 & 0x2000) != 0) {
             playSound(40);
@@ -280,64 +302,24 @@ public class ItemListScreen extends MenuScreen {
       case GLFW_KEY_ESCAPE -> this.loadingStage = 100;
 
       case GLFW_KEY_DOWN -> {
-        if(this.leftSide) {
-          if(this.selectedSlotEquipment < 6) {
-            playSound(1);
-            this.selectedSlotEquipment++;
-          } else if(this.slotScrollEquipment < gameState_800babc8.equipmentCount_1e4.get() + (int)this.equippedItemsCount - 7) {
-            playSound(1);
-            this.slotScrollEquipment++;
-          }
-
-          this.equipmentHighlight.y_44 = FUN_800fc814(this.selectedSlotEquipment) + 32;
-          this.setCurrent(gameState_800babc8.equipment_1e8, this.equipment, this.slotScrollEquipment + this.selectedSlotEquipment);
-        } else {
-          if(this.selectedSlotItem < 6) {
-            playSound(1);
-            this.selectedSlotItem++;
-          } else if(this.slotScrollItem < gameState_800babc8.itemCount_1e6.get() - 7) {
-            playSound(1);
-            this.slotScrollItem++;
-          }
-
-          this.itemHighlight.y_44 = FUN_800fc814(this.selectedSlotItem) + 32;
-          this.setCurrent(gameState_800babc8.items_2e9, this.items, this.slotScrollItem + this.selectedSlotItem);
-        }
+        this.handleVerticalInput(false);
       }
       case GLFW_KEY_UP -> {
-        if(this.leftSide) {
-          if(this.selectedSlotEquipment > 0) {
-            playSound(1);
-            this.selectedSlotEquipment--;
-          } else if(this.slotScrollEquipment > 0) {
-            playSound(1);
-            this.slotScrollEquipment--;
-          }
-
-          this.equipmentHighlight.y_44 = FUN_800fc814(this.selectedSlotEquipment) + 32;
-          this.setCurrent(gameState_800babc8.equipment_1e8, this.equipment, this.slotScrollEquipment + this.selectedSlotEquipment);
-        } else {
-          if(this.selectedSlotItem > 0) {
-            playSound(1);
-            this.selectedSlotItem--;
-          } else if(this.slotScrollItem > 0) {
-            playSound(1);
-            this.slotScrollItem--;
-          }
-
-          this.itemHighlight.y_44 = FUN_800fc814(this.selectedSlotItem) + 32;
-          this.setCurrent(gameState_800babc8.items_2e9, this.items, this.slotScrollItem + this.selectedSlotItem);
-        }
+        this.handleVerticalInput(true);
       }
 
       case GLFW_KEY_LEFT -> {
         playSound(1);
         this.leftSide = true;
+        this.setCurrent(gameState_800babc8.equipment_1e8, this.equipment, this.slotScrollEquipment + this.selectedSlot);
+        this.highlight.x_40 = FUN_800fc824(0);
       }
 
       case GLFW_KEY_RIGHT -> {
         playSound(1);
         this.leftSide = false;
+        this.setCurrent(gameState_800babc8.items_2e9, this.items, this.slotScrollItem + this.selectedSlot);
+        this.highlight.x_40 = FUN_800fc824(1);
       }
 
       case GLFW_KEY_ENTER -> {

--- a/src/main/java/legend/game/inventory/screens/ItemListScreen.java
+++ b/src/main/java/legend/game/inventory/screens/ItemListScreen.java
@@ -132,8 +132,6 @@ public class ItemListScreen extends MenuScreen {
             }
           }
         }
-
-
       }
 
       // Fade out
@@ -150,8 +148,7 @@ public class ItemListScreen extends MenuScreen {
     }
   }
 
-  private void handleVerticalInput(final boolean isScrollingUp)
-  {
+  private void handleVerticalInput(final boolean isScrollingUp) {
     if(this.leftSide) {
       if(isScrollingUp ? this.selectedSlot > 0 : this.selectedSlot < 6) {
         playSound(1);

--- a/src/main/java/legend/game/inventory/screens/ItemListScreen.java
+++ b/src/main/java/legend/game/inventory/screens/ItemListScreen.java
@@ -220,7 +220,8 @@ public class ItemListScreen extends MenuScreen {
         if(this.selectedSlot != i && MathHelper.inBox(x, y, 8, 31 + FUN_800fc814(i), 174, 17)) {
           playSound(1);
           this.selectedSlot = i;
-//          this.equipmentHighlight.y_44 = FUN_800fc814(i) + 32;
+          this.highlight.y_44 = FUN_800fc814(i) + 32;
+          this.highlight.x_40 = FUN_800fc824(0);
           this.setCurrent(gameState_800babc8.equipment_1e8, this.equipment, this.slotScrollEquipment + this.selectedSlot);
         }
       }
@@ -229,7 +230,8 @@ public class ItemListScreen extends MenuScreen {
         if(this.selectedSlot != i && MathHelper.inBox(x, y, 186, 31 + FUN_800fc814(i), 174, 17)) {
           playSound(1);
           this.selectedSlot = i;
-//          this.itemHighlight.y_44 = FUN_800fc814(i) + 32;
+          this.highlight.y_44 = FUN_800fc814(i) + 32;
+          this.highlight.x_40 = FUN_800fc824(1);
           this.setCurrent(gameState_800babc8.items_2e9, this.items, this.slotScrollItem + this.selectedSlot);
         }
       }
@@ -247,7 +249,8 @@ public class ItemListScreen extends MenuScreen {
         if(MathHelper.inBox(x, y, 8, 31 + FUN_800fc814(i), 174, 17)) {
           playSound(1);
           this.selectedSlot = i;
-//          this.equipmentHighlight.y_44 = FUN_800fc814(i) + 32;
+          this.highlight.y_44 = FUN_800fc814(i) + 32;
+          this.highlight.x_40 = FUN_800fc824(0);
           this.setCurrent(gameState_800babc8.equipment_1e8, this.equipment, this.slotScrollEquipment + this.selectedSlot);
 
           if((this.currentDisplayList.get(this.currentIndex).flags_02 & 0x2000) != 0) {
@@ -263,7 +266,8 @@ public class ItemListScreen extends MenuScreen {
         if(MathHelper.inBox(x, y, 186, 31 + FUN_800fc814(i), 174, 17)) {
           playSound(1);
           this.selectedSlot = i;
-//          this.itemHighlight.y_44 = FUN_800fc814(i) + 32;
+          this.highlight.y_44 = FUN_800fc814(i) + 32;
+          this.highlight.x_40 = FUN_800fc824(1);
           this.setCurrent(gameState_800babc8.items_2e9, this.items, this.slotScrollItem + this.selectedSlot);
 
           if((this.currentDisplayList.get(this.currentIndex).flags_02 & 0x2000) != 0) {

--- a/src/main/java/legend/game/inventory/screens/ItemListScreen.java
+++ b/src/main/java/legend/game/inventory/screens/ItemListScreen.java
@@ -217,7 +217,7 @@ public class ItemListScreen extends MenuScreen {
 
     if(this.loadingStage == 1) {
       for(int i = 0; i < Math.min(7, gameState_800babc8.equipmentCount_1e4.get() - this.slotScrollEquipment); i++) {
-        if(this.selectedSlot != i && MathHelper.inBox(x, y, 8, 31 + FUN_800fc814(i), 174, 17)) {
+        if(MathHelper.inBox(x, y, 8, 31 + FUN_800fc814(i), 174, 17)) {
           playSound(1);
           this.selectedSlot = i;
           this.highlight.y_44 = FUN_800fc814(i) + 32;
@@ -227,7 +227,7 @@ public class ItemListScreen extends MenuScreen {
       }
 
       for(int i = 0; i < Math.min(7, gameState_800babc8.itemCount_1e6.get() - this.slotScrollItem); i++) {
-        if(this.selectedSlot != i && MathHelper.inBox(x, y, 186, 31 + FUN_800fc814(i), 174, 17)) {
+        if(MathHelper.inBox(x, y, 186, 31 + FUN_800fc814(i), 174, 17)) {
           playSound(1);
           this.selectedSlot = i;
           this.highlight.y_44 = FUN_800fc814(i) + 32;

--- a/src/main/java/legend/game/inventory/screens/ItemListScreen.java
+++ b/src/main/java/legend/game/inventory/screens/ItemListScreen.java
@@ -148,6 +148,10 @@ public class ItemListScreen extends MenuScreen {
     }
   }
 
+  private void handleMenuFocusState(final boolean leftSide) {
+    this.leftSide = leftSide;
+  }
+
   private void handleVerticalInput(final boolean isScrollingUp) {
     if(this.leftSide) {
       if(isScrollingUp ? this.selectedSlot > 0 : this.selectedSlot < 6) {
@@ -219,6 +223,7 @@ public class ItemListScreen extends MenuScreen {
       for(int i = 0; i < Math.min(7, gameState_800babc8.equipmentCount_1e4.get() - this.slotScrollEquipment); i++) {
         if(MathHelper.inBox(x, y, 8, 31 + FUN_800fc814(i), 174, 17)) {
           playSound(1);
+          this.handleMenuFocusState(true);
           this.selectedSlot = i;
           this.highlight.y_44 = FUN_800fc814(i) + 32;
           this.highlight.x_40 = FUN_800fc824(0);
@@ -229,6 +234,7 @@ public class ItemListScreen extends MenuScreen {
       for(int i = 0; i < Math.min(7, gameState_800babc8.itemCount_1e6.get() - this.slotScrollItem); i++) {
         if(MathHelper.inBox(x, y, 186, 31 + FUN_800fc814(i), 174, 17)) {
           playSound(1);
+          this.handleMenuFocusState(false);
           this.selectedSlot = i;
           this.highlight.y_44 = FUN_800fc814(i) + 32;
           this.highlight.x_40 = FUN_800fc824(1);
@@ -248,6 +254,7 @@ public class ItemListScreen extends MenuScreen {
       for(int i = 0; i < Math.min(7, gameState_800babc8.equipmentCount_1e4.get() - this.slotScrollEquipment); i++) {
         if(MathHelper.inBox(x, y, 8, 31 + FUN_800fc814(i), 174, 17)) {
           playSound(1);
+          this.handleMenuFocusState(true);
           this.selectedSlot = i;
           this.highlight.y_44 = FUN_800fc814(i) + 32;
           this.highlight.x_40 = FUN_800fc824(0);
@@ -265,6 +272,7 @@ public class ItemListScreen extends MenuScreen {
       for(int i = 0; i < Math.min(7, gameState_800babc8.itemCount_1e6.get() - this.slotScrollItem); i++) {
         if(MathHelper.inBox(x, y, 186, 31 + FUN_800fc814(i), 174, 17)) {
           playSound(1);
+          this.handleMenuFocusState(false);
           this.selectedSlot = i;
           this.highlight.y_44 = FUN_800fc814(i) + 32;
           this.highlight.x_40 = FUN_800fc824(1);
@@ -311,14 +319,14 @@ public class ItemListScreen extends MenuScreen {
 
       case GLFW_KEY_LEFT -> {
         playSound(1);
-        this.leftSide = true;
+        this.handleMenuFocusState(true);
         this.setCurrent(gameState_800babc8.equipment_1e8, this.equipment, this.slotScrollEquipment + this.selectedSlot);
         this.highlight.x_40 = FUN_800fc824(0);
       }
 
       case GLFW_KEY_RIGHT -> {
         playSound(1);
-        this.leftSide = false;
+        this.handleMenuFocusState(false);
         this.setCurrent(gameState_800babc8.items_2e9, this.items, this.slotScrollItem + this.selectedSlot);
         this.highlight.x_40 = FUN_800fc824(1);
       }

--- a/src/main/java/legend/game/inventory/screens/ItemListScreen.java
+++ b/src/main/java/legend/game/inventory/screens/ItemListScreen.java
@@ -332,7 +332,11 @@ public class ItemListScreen extends MenuScreen {
       }
 
       case GLFW_KEY_ENTER, GLFW_KEY_S -> {
-        if((this.currentDisplayList.get(this.currentIndex).flags_02 & 0x2000) != 0) {
+        if(this.currentIndex >= this.currentDisplayList.size()) {
+          break;
+        }
+
+        if(((this.currentDisplayList.get(this.currentIndex).flags_02 & 0x2000) != 0)) {
           playSound(40);
         } else {
           playSound(2);

--- a/src/main/java/legend/game/inventory/screens/ItemListScreen.java
+++ b/src/main/java/legend/game/inventory/screens/ItemListScreen.java
@@ -331,7 +331,7 @@ public class ItemListScreen extends MenuScreen {
         this.highlight.x_40 = FUN_800fc824(1);
       }
 
-      case GLFW_KEY_ENTER -> {
+      case GLFW_KEY_ENTER, GLFW_KEY_S -> {
         if((this.currentDisplayList.get(this.currentIndex).flags_02 & 0x2000) != 0) {
           playSound(40);
         } else {

--- a/src/main/java/legend/game/inventory/screens/ShopScreen.java
+++ b/src/main/java/legend/game/inventory/screens/ShopScreen.java
@@ -701,7 +701,7 @@ public class ShopScreen extends MenuScreen {
         this.renderable_8011e0f0 = allocateUiElement(0x3d, 0x44, 358, FUN_8010a808(0));
         this.renderable_8011e0f4 = allocateUiElement(0x35, 0x3c, 358, FUN_8010a808(5));
 
-        menuStack.pushScreen(new MessageBoxScreen(new LodString("What do you want to sell?"), new LodString("Equipment"), new LodString("Items"), 2, result -> {
+        menuStack.pushScreen(new MessageBoxScreen(new LodString("What do you want to sell?"), new LodString("Armed"), new LodString("Items"), 2, result -> {
           switch(result) {
             case YES -> {
               this.menuIndex_8011e0e0 = 0;


### PR DESCRIPTION
## List Menu Bug Fix - #294 

• Refactored render code to be simpler with sharing one highlighter, one selectSlot
• Refactored vertical input handling to be as straightforward as a shared state dual pane distinct menu system can be
• Added logic that was missing to the Left and Right toggles of state 

• This may have conflicts with #268 (which did not address this bug)

## Equipment => Armed

• Equipment broke out of the boundaries on the Sell => Equipment/Items menu
• Armed is the original name and Armed is used elsewhere in the Menu system
• I did not restore the original menu in the mid left of the screen but kept the one already present
• See following screenshots for details

### Original Bug
![image](https://user-images.githubusercontent.com/29797557/222496458-aa3e224e-574c-4c69-acda-2247070a0fc0.png)

### What Retail Looks Like
![image](https://user-images.githubusercontent.com/29797557/222502655-cee4b82d-0d81-4cd3-9eaf-639b195867a9.png)

### What The Fix Looks Like
![image](https://user-images.githubusercontent.com/29797557/222506139-6ebc00b1-47a0-446a-977e-a09e40c5924d.png)