### PR TITLE
Disable status effects

### DIFF
--- a/src/main/java/legend/core/Config.java
+++ b/src/main/java/legend/core/Config.java
@@ -110,6 +110,14 @@ public final class Config {
     properties.setProperty("auto_dragoon_meter", String.valueOf(!autoDragoonMeter()));
   }
 
+  public static boolean disableStatusEffects() {
+    return readBool("disable_status_effects", false);
+  }
+
+  public static void toggleDisableStatusEffects() {
+    properties.setProperty("disable_status_effects", String.valueOf(!disableStatusEffects()));
+  }
+
   public static boolean combatStage() {
     return readBool("combat_stage", false);
   }

--- a/src/main/java/legend/game/debugger/DebuggerController.java
+++ b/src/main/java/legend/game/debugger/DebuggerController.java
@@ -75,6 +75,8 @@ public class DebuggerController {
   @FXML
   public CheckBox autoMeter;
   @FXML
+  public CheckBox disableStatusEffects;
+  @FXML
   public CheckBox combatStage;
   @FXML
   public CheckBox fastTextSpeed;
@@ -94,6 +96,7 @@ public class DebuggerController {
     this.battleUIColourB.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(0, 255, ((Config.getBattleRGB() >> 16)  & 0xff)));
     this.autoAddition.setSelected(Config.autoAddition());
     this.autoMeter.setSelected(Config.autoDragoonMeter());
+    this.disableStatusEffects.setSelected(Config.disableStatusEffects());
     this.combatStage.setSelected(Config.combatStage());
     this.combatStageId.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(0, 127, Config.getCombatStage()));
     this.fastTextSpeed.setSelected(Config.fastTextSpeed());
@@ -228,6 +231,11 @@ public class DebuggerController {
   @FXML
   private void toggleAutoDragoonMeter(final ActionEvent event) {
     Config.toggleAutoDragoonMeter();
+  }
+
+  @FXML
+  private void toggleDisableStatusEffects(final ActionEvent event) {
+    Config.toggleDisableStatusEffects();
   }
 
   @FXML

--- a/src/main/resources/legend/game/debugger/debugger.fxml
+++ b/src/main/resources/legend/game/debugger/debugger.fxml
@@ -86,6 +86,7 @@
                </HBox>
                <CheckBox fx:id="autoAddition" mnemonicParsing="false" onAction="#toggleAutoAddition" text="Auto Additions" />
                <CheckBox fx:id="autoMeter" mnemonicParsing="false" onAction="#toggleAutoDragoonMeter" text="Auto Dragoon Meter" />
+               <CheckBox fx:id="disableStatusEffects" mnemonicParsing="false" onAction="#toggleDisableStatusEffects" text="Disable Status Effects"/>
             </children>
          </VBox>
       </HBox>


### PR DESCRIPTION
Adds option to disable status effects to debugger. Only applies to the party.

The logic is supposed to be that if the option is enabled, the status effect code should still be entered if the "attacker" is the player, but that if the attacker is an enemy it will always be skipped.

Closes #312 