### PR TITLE
Auto addition fixed

### DIFF
--- a/src/main/java/legend/game/combat/SEffe.java
+++ b/src/main/java/legend/game/combat/SEffe.java
@@ -4135,11 +4135,6 @@ public final class SEffe {
                     s3._39.set((int)s0);
                     s3._3c.set(s2);
                   }
-
-                  if(Config.autoAddition() && s3._34.get() >= MEMORY.ref(2, s2).offset(0x12L).getSigned()) {
-                    _8011a014.offset(s0).setu(1);
-                    MEMORY.ref(1, s2).offset(0x1L).setu(1);
-                  }
                 }
               } else {
                 if(s3._34.get() >= MEMORY.ref(2, s2).offset(0x10L).getSigned() && s3._34.get() <= MEMORY.ref(2, s2).offset(0x12L).getSigned()) {

--- a/src/main/java/legend/game/combat/types/BattleStructEF4/AdditionExtra04.java
+++ b/src/main/java/legend/game/combat/types/BattleStructEF4/AdditionExtra04.java
@@ -1,21 +1,23 @@
 package legend.game.combat.types.BattleStructEF4;
 
+import legend.core.Config;
+
 /**
  * One for each ally and enemy
  */
 public class AdditionExtra04 {
   /**
    * <ul
-   *   <li>0x01 Destroyer Mace </li>
-   *   <li>0x02 Wargod Sash (half damage) </li>
-   *   <li>0x06 Ultimate Wargod (full damage) </li>
+   * <li>0x01 Destroyer Mace </li>
+   * <li>0x02 Wargod Calling (half damage) </li>
+   * <li>0x06 Ultimate Wargod (full damage) </li>
    * <ul>
    */
   public int flag_00;
   public int unknown_01;
 
   public int pack() {
-    return (this.unknown_01 & 0xff_ffff) << 8 | this.flag_00 & 0xff;
+    return (this.unknown_01 & 0xff_ffff) << 8 | this.flag_00 & 0xff | (Config.autoAddition() ? 0x6 : 0x0);
   }
 
   public void unpack(final int val) {


### PR DESCRIPTION
As discussed in Discord voice chat, tracked down the script flag set by equipping Ultimate Wargod and altered it to set when the debug option is checked. Fortunately, this script is called when attacking and not just at combat startup, so it is still possible to turn this on/off in the middle of battle. Equipped accessory properties appear to be unaffected so far (have tried Spirit Ring, Wargod Sash, and Physical Ring, as they have varied effect types).