### PR TITLE
Retail Accurate item and equipment sorting

### DIFF
--- a/src/main/java/legend/game/Scus94491BpeSegment_8002.java
+++ b/src/main/java/legend/game/Scus94491BpeSegment_8002.java
@@ -1955,8 +1955,8 @@ public final class Scus94491BpeSegment_8002 {
   @Method(0x80023a2cL)
   public static void sortItems(final List<MenuItemStruct04> display, final ArrayRef<UnsignedByteRef> items, final int count) {
     display.sort(Comparator
-      .comparingInt((MenuItemStruct04 item) -> item.itemId_00)
-      .thenComparing(item -> equipment_8011972c.get(item.itemId_00).deref().get())
+      .comparingInt((MenuItemStruct04 item) -> getItemIcon(item.itemId_00))
+      .thenComparingInt(item -> item.itemId_00)
     );
 
     setInventoryFromDisplay(display, items, count);

--- a/src/main/java/legend/game/Scus94491BpeSegment_8002.java
+++ b/src/main/java/legend/game/Scus94491BpeSegment_8002.java
@@ -78,6 +78,7 @@ import static legend.core.GameEngine.MEMORY;
 import static legend.core.GameEngine.SCRIPTS;
 import static legend.game.SItem.FUN_80103b10;
 import static legend.game.SItem.equipmentStats_80111ff0;
+import static legend.game.SItem.equipment_8011972c;
 import static legend.game.SItem.loadCharacterStats;
 import static legend.game.SItem.magicStuff_80111d20;
 import static legend.game.SItem.menuStack;
@@ -1953,9 +1954,14 @@ public final class Scus94491BpeSegment_8002 {
 
   @Method(0x80023a2cL)
   public static void sortItems(final List<MenuItemStruct04> display, final ArrayRef<UnsignedByteRef> items, final int count) {
-    display.sort(Comparator.comparingInt(item -> getItemIcon(item.itemId_00)));
+    display.sort(Comparator
+      .comparingInt((MenuItemStruct04 item) -> item.itemId_00)
+      .thenComparing(item -> equipment_8011972c.get(item.itemId_00).deref().get())
+    );
+
     setInventoryFromDisplay(display, items, count);
   }
+
 
   @Method(0x80023a88L)
   public static void FUN_80023a88() {

--- a/src/main/java/legend/game/Scus94491BpeSegment_8002.java
+++ b/src/main/java/legend/game/Scus94491BpeSegment_8002.java
@@ -1962,7 +1962,6 @@ public final class Scus94491BpeSegment_8002 {
     setInventoryFromDisplay(display, items, count);
   }
 
-
   @Method(0x80023a88L)
   public static void FUN_80023a88() {
     final List<MenuItemStruct04> items = new ArrayList<>();

--- a/src/main/java/legend/game/Scus94491BpeSegment_8002.java
+++ b/src/main/java/legend/game/Scus94491BpeSegment_8002.java
@@ -78,7 +78,6 @@ import static legend.core.GameEngine.MEMORY;
 import static legend.core.GameEngine.SCRIPTS;
 import static legend.game.SItem.FUN_80103b10;
 import static legend.game.SItem.equipmentStats_80111ff0;
-import static legend.game.SItem.equipment_8011972c;
 import static legend.game.SItem.loadCharacterStats;
 import static legend.game.SItem.magicStuff_80111d20;
 import static legend.game.SItem.menuStack;


### PR DESCRIPTION
Retail seems to sort by icon and then by item id. 

Tested against Emulator and PS1 sorting...seems to match up but hard to get 1:1 comparisons for all items.

Commit history has sub-sorting alphabetically for future reference. #options #mods

Closes #220 

*No idea the CS for the chained comparator delegates.*