### PR TITLE
Main menu selector wraps / loops

### DIFF
--- a/src/main/java/legend/game/inventory/screens/MainMenuScreen.java
+++ b/src/main/java/legend/game/inventory/screens/MainMenuScreen.java
@@ -386,11 +386,21 @@ public class MainMenuScreen extends MenuScreen {
         playSound(1);
         this.selectedMenuOption--;
         this.selectedMenuOptionRenderable.y_44 = getMenuOptionY(this.selectedMenuOption);
+      } else {
+        playSound(1);
+        this.selectedMenuOption = 5;
+        this.selectedMenuOptionRenderable.y_44 = getMenuOptionY(this.selectedMenuOption);
       }
-    } else if(this.selectedItemSubmenuOption > 0) {
-      playSound(1);
-      this.selectedItemSubmenuOption--;
-      this.selectedItemMenuOptionRenderable.y_44 = this.getItemSubmenuOptionY(this.selectedItemSubmenuOption) - 2;
+    } else {
+      if(this.selectedItemSubmenuOption > 0) {
+        playSound(1);
+        this.selectedItemSubmenuOption--;
+        this.selectedItemMenuOptionRenderable.y_44 = this.getItemSubmenuOptionY(this.selectedItemSubmenuOption) - 2;
+      } else {
+        playSound(1);
+        this.selectedItemSubmenuOption = 3;
+        this.selectedItemMenuOptionRenderable.y_44 = this.getItemSubmenuOptionY(this.selectedItemSubmenuOption) - 2;
+      }
     }
   }
 
@@ -400,11 +410,21 @@ public class MainMenuScreen extends MenuScreen {
         playSound(1);
         this.selectedMenuOption++;
         this.selectedMenuOptionRenderable.y_44 = getMenuOptionY(this.selectedMenuOption);
+      } else {
+        playSound(1);
+        this.selectedMenuOption = 0;
+        this.selectedMenuOptionRenderable.y_44 = getMenuOptionY(this.selectedMenuOption);
       }
-    } else if(this.selectedItemSubmenuOption < 3) {
-      playSound(1);
-      this.selectedItemSubmenuOption++;
-      this.selectedItemMenuOptionRenderable.y_44 = this.getItemSubmenuOptionY(this.selectedItemSubmenuOption) - 2;
+    } else {
+      if(this.selectedItemSubmenuOption < 3) {
+        playSound(1);
+        this.selectedItemSubmenuOption++;
+        this.selectedItemMenuOptionRenderable.y_44 = this.getItemSubmenuOptionY(this.selectedItemSubmenuOption) - 2;
+      } else {
+        playSound(1);
+        this.selectedItemSubmenuOption = 0;
+        this.selectedItemMenuOptionRenderable.y_44 = this.getItemSubmenuOptionY(this.selectedItemSubmenuOption) - 2;
+      }
     }
   }
 

--- a/src/main/java/legend/game/inventory/screens/MainMenuScreen.java
+++ b/src/main/java/legend/game/inventory/screens/MainMenuScreen.java
@@ -381,51 +381,29 @@ public class MainMenuScreen extends MenuScreen {
   }
 
   private void menuNavigateUp() {
+    playSound(1);
+
     if(this.onLeftMenu) {
-      if(this.selectedMenuOption > 0) {
-        playSound(1);
-        this.selectedMenuOption--;
-        this.selectedMenuOptionRenderable.y_44 = getMenuOptionY(this.selectedMenuOption);
-      } else {
-        playSound(1);
-        this.selectedMenuOption = 5;
-        this.selectedMenuOptionRenderable.y_44 = getMenuOptionY(this.selectedMenuOption);
-      }
-    } else {
-      if(this.selectedItemSubmenuOption > 0) {
-        playSound(1);
-        this.selectedItemSubmenuOption--;
-        this.selectedItemMenuOptionRenderable.y_44 = this.getItemSubmenuOptionY(this.selectedItemSubmenuOption) - 2;
-      } else {
-        playSound(1);
-        this.selectedItemSubmenuOption = 3;
-        this.selectedItemMenuOptionRenderable.y_44 = this.getItemSubmenuOptionY(this.selectedItemSubmenuOption) - 2;
-      }
+      this.selectedMenuOption = this.selectedMenuOption > 0 ? --this.selectedMenuOption : 5;
+      this.selectedMenuOptionRenderable.y_44 = getMenuOptionY(this.selectedMenuOption);
+      return;
     }
+
+    this.selectedItemSubmenuOption = this.selectedItemSubmenuOption > 0 ? --this.selectedItemSubmenuOption : 3;
+    this.selectedItemMenuOptionRenderable.y_44 = this.getItemSubmenuOptionY(this.selectedItemSubmenuOption) - 2;
   }
 
   private void menuNavigateDown() {
+    playSound(1);
+
     if(this.onLeftMenu) {
-      if(this.selectedMenuOption < 5) {
-        playSound(1);
-        this.selectedMenuOption++;
-        this.selectedMenuOptionRenderable.y_44 = getMenuOptionY(this.selectedMenuOption);
-      } else {
-        playSound(1);
-        this.selectedMenuOption = 0;
-        this.selectedMenuOptionRenderable.y_44 = getMenuOptionY(this.selectedMenuOption);
-      }
-    } else {
-      if(this.selectedItemSubmenuOption < 3) {
-        playSound(1);
-        this.selectedItemSubmenuOption++;
-        this.selectedItemMenuOptionRenderable.y_44 = this.getItemSubmenuOptionY(this.selectedItemSubmenuOption) - 2;
-      } else {
-        playSound(1);
-        this.selectedItemSubmenuOption = 0;
-        this.selectedItemMenuOptionRenderable.y_44 = this.getItemSubmenuOptionY(this.selectedItemSubmenuOption) - 2;
-      }
+      this.selectedMenuOption = this.selectedMenuOption < 5 ? ++this.selectedMenuOption : 0;
+      this.selectedMenuOptionRenderable.y_44 = getMenuOptionY(this.selectedMenuOption);
+      return;
     }
+
+    this.selectedItemSubmenuOption = this.selectedItemSubmenuOption < 3 ? ++this.selectedItemSubmenuOption : 0;
+    this.selectedItemMenuOptionRenderable.y_44 = this.getItemSubmenuOptionY(this.selectedItemSubmenuOption) - 2;
   }
 
   private void menuNavigateLeft() {


### PR DESCRIPTION
Added the functionality to wrap and massively reduced the nesting / code complexity for the functionality to exist (see commit history).

In retail the only menu I found that does wrap is the main menu. The other menus don't seem to wrap.

Closes #296 