### PR TITLE
Too Many Items Input Support + ⭐Wrapping ⭐

### DIFF
--- a/src/main/java/legend/game/inventory/screens/TooManyItemsScreen.java
+++ b/src/main/java/legend/game/inventory/screens/TooManyItemsScreen.java
@@ -135,6 +135,10 @@ public class TooManyItemsScreen extends MenuScreen {
               playSound(1);
               this.invScroll--;
               this.renderable_8011e204.y_44 = this.FUN_8010f178(this.invIndex);
+            } else if(this.invScroll == 0) {
+              this.invScroll = slotCount -7;
+              this.invIndex = 6;
+              this.renderable_8011e204.y_44 = this.FUN_8010f178(this.invIndex);
             }
           }
         }
@@ -146,6 +150,10 @@ public class TooManyItemsScreen extends MenuScreen {
             if(this.invScroll < slotCount - 7) {
               playSound(1);
               this.invScroll++;
+              this.renderable_8011e204.y_44 = this.FUN_8010f178(this.invIndex);
+            } else if(this.invScroll == slotCount - 7) {
+              this.invScroll = 0;
+              this.invIndex = 0;
               this.renderable_8011e204.y_44 = this.FUN_8010f178(this.invIndex);
             }
           }
@@ -320,30 +328,27 @@ public class TooManyItemsScreen extends MenuScreen {
   }
 
   private void droppedNavigateDown() {
-    if(this.dropIndex < itemsDroppedByEnemiesCount_800bc978.get() - 1 && this.dropIndex < 5) {
-      playSound(1);
-      this.dropIndex++;
-      this.renderable_8011e200.y_44 = this.FUN_8010f178(this.dropIndex);
-      return;
-    }
-
-    playSound(2);
+    playSound(1);
+    this.dropIndex = this.dropIndex < itemsDroppedByEnemiesCount_800bc978.get() - 1 ? ++this.dropIndex : 0;
+    this.renderable_8011e200.y_44 = this.FUN_8010f178(this.dropIndex);
   }
 
   private void droppedNavigateUp() {
-    if(this.dropIndex > 0) {
-      playSound(1);
-      this.dropIndex--;
-      this.renderable_8011e200.y_44 = this.FUN_8010f178(this.dropIndex);
-      return;
-    }
-
-    playSound(2);
+    playSound(1);
+    this.dropIndex = this.dropIndex > 0 ? --this.dropIndex : itemsDroppedByEnemiesCount_800bc978.get() - 1;
+    this.renderable_8011e200.y_44 = this.FUN_8010f178(this.dropIndex);
   }
 
   private void handleInventoryScrollUp() {
+    final int slotCount = gameState_800babc8.itemCount_1e6.get();
+
     if(this.invIndex == 0 && this.invScroll > 0) {
       this.invScroll--;
+    }
+
+    if(this.invIndex == 0 && this.invScroll == 0) {
+      this.invScroll = slotCount - 7;
+      this.invIndex = 7;
     }
   }
 
@@ -353,26 +358,25 @@ public class TooManyItemsScreen extends MenuScreen {
     if(this.invIndex == 6 && this.invScroll < slotCount - 7) {
       this.invScroll++;
     }
+
+    if(this.invIndex == 6 && this.invScroll == slotCount - 7) {
+      this.invScroll = 0;
+      this.invIndex = -1;
+    }
   }
 
   private void inventoryNavigateDown() {
+    playSound(1);
     this.handleInventoryScrollDown();
-
-    if(this.invIndex < 6) {
-      playSound(1);
-      this.invIndex++;
-      this.renderable_8011e204.y_44 = this.FUN_8010f178(this.invIndex);
-    }
+    this.invIndex = this.invIndex < 6 ? ++this.invIndex : 6;
+    this.renderable_8011e204.y_44 = this.FUN_8010f178(this.invIndex);
   }
 
   private void inventoryNavigateUp() {
+    playSound(1);
     this.handleInventoryScrollUp();
-
-    if(this.invIndex > 0) {
-      playSound(1);
-      this.invIndex--;
-      this.renderable_8011e204.y_44 = this.FUN_8010f178(this.invIndex);
-    }
+    this.invIndex = this.invIndex > 0 ? --this.invIndex : 0;
+    this.renderable_8011e204.y_44 = this.FUN_8010f178(this.invIndex);
   }
 
   private void escapeMenuState8() {

--- a/src/main/java/legend/game/inventory/screens/TooManyItemsScreen.java
+++ b/src/main/java/legend/game/inventory/screens/TooManyItemsScreen.java
@@ -381,6 +381,22 @@ public class TooManyItemsScreen extends MenuScreen {
     }
   }
 
+  private void droppedNavigateDown() {
+
+  }
+
+  private void droppedNavigateUp() {
+
+  }
+
+  private void itemNavigateUp() {
+
+  }
+
+  private void itemNavigateDown() {
+
+  }
+
   @Override
   public void pressedThisFrame(final InputAction inputAction) {
     if(inputAction == InputAction.BUTTON_EAST) {
@@ -388,6 +404,24 @@ public class TooManyItemsScreen extends MenuScreen {
     }
     if(inputAction == InputAction.BUTTON_SOUTH) {
       this.menuSelect();
+    }
+
+    if(this.menuState == MenuState._8) {
+      if(inputAction == InputAction.DPAD_UP || inputAction == InputAction.JOYSTICK_LEFT_BUTTON_UP) {
+        this.droppedNavigateUp();
+      }
+      if(inputAction == InputAction.DPAD_DOWN || inputAction == InputAction.JOYSTICK_LEFT_BUTTON_DOWN) {
+        this.droppedNavigateDown();
+      }
+    }
+
+    if(this.menuState == MenuState._9) {
+      if(inputAction == InputAction.DPAD_UP || inputAction == InputAction.JOYSTICK_LEFT_BUTTON_UP) {
+        this.itemNavigateUp();
+      }
+      if(inputAction == InputAction.DPAD_DOWN || inputAction == InputAction.JOYSTICK_LEFT_BUTTON_DOWN) {
+        this.itemNavigateDown();
+      }
     }
   }
 

--- a/src/main/java/legend/game/inventory/screens/TooManyItemsScreen.java
+++ b/src/main/java/legend/game/inventory/screens/TooManyItemsScreen.java
@@ -136,7 +136,7 @@ public class TooManyItemsScreen extends MenuScreen {
               this.invScroll--;
               this.renderable_8011e204.y_44 = this.FUN_8010f178(this.invIndex);
             } else if(this.invScroll == 0) {
-              this.invScroll = slotCount -7;
+              this.invScroll = slotCount - 7;
               this.invIndex = 6;
               this.renderable_8011e204.y_44 = this.FUN_8010f178(this.invIndex);
             }

--- a/src/main/java/legend/game/inventory/screens/TooManyItemsScreen.java
+++ b/src/main/java/legend/game/inventory/screens/TooManyItemsScreen.java
@@ -382,19 +382,65 @@ public class TooManyItemsScreen extends MenuScreen {
   }
 
   private void droppedNavigateDown() {
+    if (this.dropIndex < itemsDroppedByEnemiesCount_800bc978.get() - 1 && this.dropIndex < 5) {
+      playSound(1);
+      this.dropIndex++;
+      this.renderable_8011e200.y_44 = this.FUN_8010f178(this.dropIndex);
+      return;
+    }
 
+    playSound(2);
   }
 
   private void droppedNavigateUp() {
+    if (this.dropIndex > 0) {
+      playSound(1);
+      this.dropIndex--;
+      this.renderable_8011e200.y_44 = this.FUN_8010f178(this.dropIndex);
+      return;
+    }
 
+    playSound(2);
   }
 
-  private void itemNavigateUp() {
-
+  private void handleInventoryScrollUp() {
+    if(this.invIndex == 0 && this.invScroll > 0) {
+      this.invScroll--;
+    }
   }
 
-  private void itemNavigateDown() {
+  private void handleInventoryScrollDown() {
+    final int slotCount = gameState_800babc8.itemCount_1e6.get();
 
+    if (this.invIndex == 6 && this.invScroll < slotCount - 7) {
+      this.invScroll++;
+    }
+  }
+
+  private void inventoryNavigateDown() {
+    this.handleInventoryScrollDown();
+
+    if (this.invIndex < 6) {
+      playSound(1);
+      this.invIndex++;
+      this.renderable_8011e204.y_44 = this.FUN_8010f178(this.invIndex);
+      return;
+    }
+
+    playSound(2);
+  }
+
+  private void inventoryNavigateUp() {
+    this.handleInventoryScrollUp();
+
+    if (this.invIndex > 0) {
+      playSound(1);
+      this.invIndex--;
+      this.renderable_8011e204.y_44 = this.FUN_8010f178(this.invIndex);
+      return;
+    }
+
+    playSound(2);
   }
 
   @Override
@@ -429,10 +475,10 @@ public class TooManyItemsScreen extends MenuScreen {
         // check for droppable?
       }
       if(inputAction == InputAction.DPAD_UP || inputAction == InputAction.JOYSTICK_LEFT_BUTTON_UP) {
-        this.itemNavigateUp();
+        this.inventoryNavigateUp();
       }
       if(inputAction == InputAction.DPAD_DOWN || inputAction == InputAction.JOYSTICK_LEFT_BUTTON_DOWN) {
-        this.itemNavigateDown();
+        this.inventoryNavigateDown();
       }
       return;
     }

--- a/src/main/java/legend/game/inventory/screens/TooManyItemsScreen.java
+++ b/src/main/java/legend/game/inventory/screens/TooManyItemsScreen.java
@@ -290,13 +290,7 @@ public class TooManyItemsScreen extends MenuScreen {
           this.dropIndex = i;
           this.renderable_8011e200.y_44 = this.FUN_8010f178(i);
 
-          this.invScroll = 0;
-          this.invIndex = 0;
-          final Renderable58 renderable3 = allocateUiElement(118, 118, 220, this.FUN_8010f178(0));
-          this.renderable_8011e204 = renderable3;
-          FUN_80104b60(renderable3);
-          playSound(2);
-          this.menuState = MenuState._9;
+          this.selectMenuState8();
         }
       }
     } else if(this.menuState == MenuState._9) {
@@ -306,37 +300,7 @@ public class TooManyItemsScreen extends MenuScreen {
           this.invIndex = i;
           this.renderable_8011e204.y_44 = this.FUN_8010f178(i);
 
-          final MenuItemStruct04 newItem = this.droppedItems.get(this.dropIndex);
-          final int isItem = this.droppedItems.get(this.dropIndex).itemId_00 >= 0xc0 ? 1 : 0;
-          final MenuItemStruct04 existingItem;
-          if(isItem == 0) {
-            existingItem = this.equipment.get(this.invIndex + this.invScroll);
-          } else {
-            existingItem = this.items.get(this.invIndex + this.invScroll);
-          }
-
-          if((existingItem.flags_02 & 0x6000) != 0) {
-            playSound(40);
-          } else {
-            final int itemId = existingItem.itemId_00;
-            final int flags = existingItem.flags_02;
-
-            existingItem.itemId_00 = newItem.itemId_00;
-            existingItem.flags_02 = newItem.flags_02;
-
-            newItem.itemId_00 = itemId;
-            newItem.flags_02 = flags;
-
-            playSound(2);
-            unloadRenderable(this.renderable_8011e204);
-            this.menuState = MenuState._8;
-
-            if(isItem != 0) {
-              setInventoryFromDisplay(this.items, gameState_800babc8.items_2e9, gameState_800babc8.itemCount_1e6.get());
-            } else {
-              setInventoryFromDisplay(this.equipment, gameState_800babc8.equipment_1e8, gameState_800babc8.equipmentCount_1e4.get());
-            }
-          }
+          this.selectMenuState9();
         }
       }
     }
@@ -355,34 +319,8 @@ public class TooManyItemsScreen extends MenuScreen {
     this.scrollAccumulator += deltaY;
   }
 
-  private void menuEscape() {
-    if(this.menuState == MenuState._8) {
-      playSound(3);
-      unloadRenderable(this.renderable_8011e200);
-      this.menuState = MenuState._10;
-    } else if(this.menuState == MenuState._9) {
-      playSound(3);
-      unloadRenderable(this.renderable_8011e204);
-      this.menuState = MenuState._8;
-    }
-  }
-
-  private void menuSelect() {
-    if(this.menuState != MenuState._9) {
-      return;
-    }
-
-    playSound(2);
-
-    if(this.droppedItems.get(this.dropIndex).itemId_00 < 0xc0) {
-      sortItems(this.equipment, gameState_800babc8.equipment_1e8, gameState_800babc8.equipmentCount_1e4.get());
-    } else {
-      sortItems(this.items, gameState_800babc8.items_2e9, gameState_800babc8.itemCount_1e6.get());
-    }
-  }
-
   private void droppedNavigateDown() {
-    if (this.dropIndex < itemsDroppedByEnemiesCount_800bc978.get() - 1 && this.dropIndex < 5) {
+    if(this.dropIndex < itemsDroppedByEnemiesCount_800bc978.get() - 1 && this.dropIndex < 5) {
       playSound(1);
       this.dropIndex++;
       this.renderable_8011e200.y_44 = this.FUN_8010f178(this.dropIndex);
@@ -393,7 +331,7 @@ public class TooManyItemsScreen extends MenuScreen {
   }
 
   private void droppedNavigateUp() {
-    if (this.dropIndex > 0) {
+    if(this.dropIndex > 0) {
       playSound(1);
       this.dropIndex--;
       this.renderable_8011e200.y_44 = this.FUN_8010f178(this.dropIndex);
@@ -412,7 +350,7 @@ public class TooManyItemsScreen extends MenuScreen {
   private void handleInventoryScrollDown() {
     final int slotCount = gameState_800babc8.itemCount_1e6.get();
 
-    if (this.invIndex == 6 && this.invScroll < slotCount - 7) {
+    if(this.invIndex == 6 && this.invScroll < slotCount - 7) {
       this.invScroll++;
     }
   }
@@ -420,27 +358,91 @@ public class TooManyItemsScreen extends MenuScreen {
   private void inventoryNavigateDown() {
     this.handleInventoryScrollDown();
 
-    if (this.invIndex < 6) {
+    if(this.invIndex < 6) {
       playSound(1);
       this.invIndex++;
       this.renderable_8011e204.y_44 = this.FUN_8010f178(this.invIndex);
-      return;
     }
-
-    playSound(2);
   }
 
   private void inventoryNavigateUp() {
     this.handleInventoryScrollUp();
 
-    if (this.invIndex > 0) {
+    if(this.invIndex > 0) {
       playSound(1);
       this.invIndex--;
       this.renderable_8011e204.y_44 = this.FUN_8010f178(this.invIndex);
-      return;
+    }
+  }
+
+  private void escapeMenuState8() {
+    playSound(3);
+    unloadRenderable(this.renderable_8011e200);
+    this.menuState = MenuState._10;
+  }
+
+  private void selectMenuState8() {
+    final Renderable58 renderable3 = allocateUiElement(118, 118, 220, this.FUN_8010f178(0));
+    this.renderable_8011e204 = renderable3;
+    FUN_80104b60(renderable3);
+    playSound(2);
+    this.menuState = MenuState._9;
+  }
+
+  private void escapeMenuState9() {
+    this.invScroll = 0;
+    this.invIndex = 0;
+
+    playSound(3);
+    unloadRenderable(this.renderable_8011e204);
+    this.menuState = MenuState._8;
+  }
+
+  private void selectMenuState9() {
+    final MenuItemStruct04 newItem = this.droppedItems.get(this.dropIndex);
+    final int isItem = this.droppedItems.get(this.dropIndex).itemId_00 >= 0xc0 ? 1 : 0;
+    final MenuItemStruct04 existingItem;
+    if(isItem == 0) {
+      existingItem = this.equipment.get(this.invIndex + this.invScroll);
+    } else {
+      existingItem = this.items.get(this.invIndex + this.invScroll);
     }
 
+    if((existingItem.flags_02 & 0x6000) != 0) {
+      playSound(40);
+    } else {
+      final int itemId = existingItem.itemId_00;
+      final int flags = existingItem.flags_02;
+
+      existingItem.itemId_00 = newItem.itemId_00;
+      existingItem.flags_02 = newItem.flags_02;
+
+      newItem.itemId_00 = itemId;
+      newItem.flags_02 = flags;
+
+      if(isItem != 0) {
+        setInventoryFromDisplay(this.items, gameState_800babc8.items_2e9, gameState_800babc8.itemCount_1e6.get());
+      } else {
+        setInventoryFromDisplay(this.equipment, gameState_800babc8.equipment_1e8, gameState_800babc8.equipmentCount_1e4.get());
+      }
+
+      this.invScroll = 0;
+      this.invIndex = 0;
+
+      playSound(2);
+      unloadRenderable(this.renderable_8011e204);
+      this.menuState = MenuState._8;
+    }
+  }
+
+  private void sortMenuState9() {
     playSound(2);
+
+    if(this.droppedItems.get(this.dropIndex).itemId_00 < 0xc0) {
+      sortItems(this.equipment, gameState_800babc8.equipment_1e8, gameState_800babc8.equipmentCount_1e4.get());
+    } else {
+      sortItems(this.items, gameState_800babc8.items_2e9, gameState_800babc8.itemCount_1e6.get());
+    }
   }
 
   @Override
@@ -448,13 +450,30 @@ public class TooManyItemsScreen extends MenuScreen {
 
     if(this.menuState == MenuState._8) {
       if(inputAction == InputAction.BUTTON_EAST) {
-        // return to state 10 or 12 to prompt discard items
-        // handle allocation renderables
+        this.escapeMenuState8();
       }
       if(inputAction == InputAction.BUTTON_SOUTH) {
-        // confirm dropped item as selected and move to state 9
-        // handle renderables
+        this.selectMenuState8();
       }
+      return;
+    }
+
+    if(this.menuState == MenuState._9) {
+      if(inputAction == InputAction.BUTTON_EAST) {
+        this.escapeMenuState9();
+      }
+      if(inputAction == InputAction.BUTTON_SOUTH) {
+        this.selectMenuState9();
+      }
+      if(inputAction == InputAction.BUTTON_NORTH) {
+        this.sortMenuState9();
+      }
+    }
+  }
+
+  @Override
+  public void pressedWithRepeatPulse(final InputAction inputAction) {
+    if(this.menuState == MenuState._8) {
       if(inputAction == InputAction.DPAD_UP || inputAction == InputAction.JOYSTICK_LEFT_BUTTON_UP) {
         this.droppedNavigateUp();
       }
@@ -465,29 +484,12 @@ public class TooManyItemsScreen extends MenuScreen {
     }
 
     if(this.menuState == MenuState._9) {
-      if(inputAction == InputAction.BUTTON_EAST) {
-        // move back to state 8, also handle swapping renderables
-      }
-      if(inputAction == InputAction.BUTTON_SOUTH) {
-        // confirm item to swap with dropped item
-        // return to state 8
-        // handle renderables
-        // check for droppable?
-      }
       if(inputAction == InputAction.DPAD_UP || inputAction == InputAction.JOYSTICK_LEFT_BUTTON_UP) {
         this.inventoryNavigateUp();
       }
       if(inputAction == InputAction.DPAD_DOWN || inputAction == InputAction.JOYSTICK_LEFT_BUTTON_DOWN) {
         this.inventoryNavigateDown();
       }
-      return;
-    }
-
-    if(inputAction == InputAction.BUTTON_EAST) {
-      this.menuEscape();
-    }
-    if(inputAction == InputAction.BUTTON_SOUTH) {
-      this.menuSelect(); //this is incorrect behaviour for the button press
     }
   }
 

--- a/src/main/java/legend/game/inventory/screens/TooManyItemsScreen.java
+++ b/src/main/java/legend/game/inventory/screens/TooManyItemsScreen.java
@@ -399,29 +399,49 @@ public class TooManyItemsScreen extends MenuScreen {
 
   @Override
   public void pressedThisFrame(final InputAction inputAction) {
-    if(inputAction == InputAction.BUTTON_EAST) {
-      this.menuEscape();
-    }
-    if(inputAction == InputAction.BUTTON_SOUTH) {
-      this.menuSelect();
-    }
 
     if(this.menuState == MenuState._8) {
+      if(inputAction == InputAction.BUTTON_EAST) {
+        // return to state 10 or 12 to prompt discard items
+        // handle allocation renderables
+      }
+      if(inputAction == InputAction.BUTTON_SOUTH) {
+        // confirm dropped item as selected and move to state 9
+        // handle renderables
+      }
       if(inputAction == InputAction.DPAD_UP || inputAction == InputAction.JOYSTICK_LEFT_BUTTON_UP) {
         this.droppedNavigateUp();
       }
       if(inputAction == InputAction.DPAD_DOWN || inputAction == InputAction.JOYSTICK_LEFT_BUTTON_DOWN) {
         this.droppedNavigateDown();
       }
+      return;
     }
 
     if(this.menuState == MenuState._9) {
+      if(inputAction == InputAction.BUTTON_EAST) {
+        // move back to state 8, also handle swapping renderables
+      }
+      if(inputAction == InputAction.BUTTON_SOUTH) {
+        // confirm item to swap with dropped item
+        // return to state 8
+        // handle renderables
+        // check for droppable?
+      }
       if(inputAction == InputAction.DPAD_UP || inputAction == InputAction.JOYSTICK_LEFT_BUTTON_UP) {
         this.itemNavigateUp();
       }
       if(inputAction == InputAction.DPAD_DOWN || inputAction == InputAction.JOYSTICK_LEFT_BUTTON_DOWN) {
         this.itemNavigateDown();
       }
+      return;
+    }
+
+    if(inputAction == InputAction.BUTTON_EAST) {
+      this.menuEscape();
+    }
+    if(inputAction == InputAction.BUTTON_SOUTH) {
+      this.menuSelect(); //this is incorrect behaviour for the button press
     }
   }
 


### PR DESCRIPTION
Tested moderately.

Closes #333

## Note
1. If this is time sensitive for RC, note I'm probably not around much of Saturday (and possibly Sunday).
2. Make commits as anyone see's fit or merge and fix after.
3. I made this off of main, instead of rc. I don't want to ruin the git history with a rebase in this instance, however. :S 
• cherry pick manually to rc? :[

## Future Reference

1. If mods permit more than 5 drops in total, the UI needs to change + some logic bounds checks.
2. If above, note game crashes above 9 dropped items.
3. The input refactors are solid enough for the current Menu system design implementation.
4. The mouse code could be refactored a bit to match current Menu system implementation.
5. Screen animation artifacts are present either due to a) things OOOC or b) states 1 to 6 and case 5
6. There are a lot of hardcoded values that should be enums...in this specifically...but also in the whole Menu system.
7. selectMenuState8 is mainly copy paste of prior existing code.