### PR TITLE
disableStatusEffect fix

### DIFF
--- a/src/main/java/legend/game/combat/Bttl_800f.java
+++ b/src/main/java/legend/game/combat/Bttl_800f.java
@@ -3335,7 +3335,7 @@ public final class Bttl_800f {
     }
 
     //LAB_800f7e98
-    if((!Config.disableStatusEffects() || isEnemyBobj1 == 0) && simpleRand() * 0x65 >> 0x10 < effectChance) {
+    if(simpleRand() * 0x65 >> 0x10 < effectChance) {
       final long statusType = bobj1.getStat((int)s3);
 
       if((statusType & 0xffL) != 0) {

--- a/src/main/java/legend/game/combat/types/BattleObject27c.java
+++ b/src/main/java/legend/game/combat/types/BattleObject27c.java
@@ -1,5 +1,6 @@
 package legend.game.combat.types;
 
+import legend.core.Config;
 import legend.core.gte.SVECTOR;
 import legend.game.types.Model124;
 
@@ -283,6 +284,13 @@ public class BattleObject27c extends BattleScriptDataBase {
   }
 
   public int getStat(final int statIndex) {
+    int disableStatusFlag = 0x0;
+    if(statIndex == 5 || statIndex == 16) {
+      disableStatusFlag = Config.disableStatusEffects() && this.combatant_144.charSlot_19c > -1 ? 0xff : 0x0;
+      if(disableStatusFlag == 0xff) {
+        this.status_0e &= 0xff00;
+      }
+    }
     return switch(statIndex) {
       case 0 -> this.level_04;
       case 1 -> this.dlevel_06;
@@ -300,7 +308,7 @@ public class BattleObject27c extends BattleScriptDataBase {
       case 13 -> this._1e;
       case 14 -> this.elementalResistanceFlag_20;
       case 15 -> this.elementalImmunityFlag_22;
-      case 16 -> this.statusResistFlag_24;
+      case 16 -> this.statusResistFlag_24 | disableStatusFlag;
       case 17 -> this._26;
       case 18 -> this._28;
       case 19 -> this._2a;


### PR DESCRIPTION
It turns out that scripted mass status effect attacks like Menon's confusion or DD's roar do not use the same code for determining and applying effects. To get it to work universally, I added checks to the bobj getStat function. Now, any time something tries to get status_0e or statusResistFlag_24, it will check whether disableStatusEffects is on and charSlot is >0 (which to my knowledge is player characters only). If it is, the character will be set to resist all statuses, and current conditions will be cured. This should catch all status effects, but things like arm blocking could use some testing in terms of whether this fix will remove it if already applied (something the old method didn't do at all).