### PR TITLE
Victory dance fixed

### DIFF
--- a/src/main/java/legend/game/combat/Bttl_800c.java
+++ b/src/main/java/legend/game/combat/Bttl_800c.java
@@ -1188,7 +1188,7 @@ public final class Bttl_800c {
       if(s0 == 1) {
         //LAB_800c8180
         for(int i = 0; i < charCount_800c677c.get(); i++) {
-          _8006e398.charBobjIndices_e40[_800c6690.get()].storage_44[7] |= 0x8;
+          _8006e398.charBobjIndices_e40[i].storage_44[7] |= 0x8;
         }
       }
     }


### PR DESCRIPTION
The script engine was checking a value on storage[7] of the bobj scripts prior to animation loading, but the flag was only being set on Dart. Turns out a single memory value set to 0 was being used to index the bobj scripts instead of the loop value.