### PR TITLE
Rendering fixes

### DIFF
--- a/src/main/java/legend/game/SMap.java
+++ b/src/main/java/legend/game/SMap.java
@@ -906,7 +906,7 @@ public final class SMap {
     CPU.CTC2(ls.transfer.getY(), 6);
     CPU.CTC2(ls.transfer.getZ(), 7);
 
-    Renderer.renderDobj2(model_800bda10.ObjTable_0c.top[0], false);
+    Renderer.renderDobj2(model_800bda10.ObjTable_0c.top[0], false, 0);
     model_800bda10.coord2ArrPtr_04[0].flg--;
   }
 
@@ -1009,7 +1009,7 @@ public final class SMap {
         CPU.CTC2(ls.transfer.getX(), 5);
         CPU.CTC2(ls.transfer.getY(), 6);
         CPU.CTC2(ls.transfer.getZ(), 7);
-        Renderer.renderDobj2(dobj2, false);
+        Renderer.renderDobj2(dobj2, false, 0);
       }
     }
 

--- a/src/main/java/legend/game/Scus94491BpeSegment_8002.java
+++ b/src/main/java/legend/game/Scus94491BpeSegment_8002.java
@@ -633,20 +633,20 @@ public final class Scus94491BpeSegment_8002 {
   public static void renderDobj2(final GsDOBJ2 dobj2) {
     if(mainCallbackIndex_8004dd20.get() == 5) {
       //LAB_800212b0
-      Renderer.renderDobj2(dobj2, false);
+      Renderer.renderDobj2(dobj2, false, 0);
       return;
     }
 
     if(mainCallbackIndex_8004dd20.get() == 6) {
       //LAB_800212a0
-      Renderer.renderDobj2(dobj2, true);
+      Renderer.renderDobj2(dobj2, true, 0);
       return;
     }
 
     //LAB_8002128c
     if(mainCallbackIndex_8004dd20.get() == 8) {
       //LAB_800212c0
-      Renderer.renderDobj2(dobj2, false);
+      Renderer.renderDobj2(dobj2, false, 0);
     }
 
     //LAB_800212c8

--- a/src/main/java/legend/game/WMap.java
+++ b/src/main/java/legend/game/WMap.java
@@ -528,7 +528,7 @@ public class WMap {
         CPU.CTC2(ls.transfer.getX(), 5);
         CPU.CTC2(ls.transfer.getY(), 6);
         CPU.CTC2(ls.transfer.getZ(), 7);
-        Renderer.renderDobj2(dobj2, false);
+        Renderer.renderDobj2(dobj2, false, 0);
       }
     }
 

--- a/src/main/java/legend/game/combat/Bttl_800d.java
+++ b/src/main/java/legend/game/combat/Bttl_800d.java
@@ -4513,6 +4513,9 @@ public final class Bttl_800d {
     return model.remainingFrames_9e;
   }
 
+  /**
+   * used renderCtmd
+   */
   @Method(0x800dd89cL)
   public static void FUN_800dd89c(final Model124 model, final int newAttribute) {
     final long v0;
@@ -4562,7 +4565,7 @@ public final class Bttl_800d {
           zShift_1f8003c4.set(2);
           zMax_1f8003cc.set(0xffe);
           zMin = 0xb;
-          Renderer.renderDobj2(s2, false);
+          Renderer.renderDobj2(s2, false, 0x20);
           zShift_1f8003c4.set(oldZShift);
           zMax_1f8003cc.set(oldZMax);
           zMin = oldZMin;
@@ -4856,6 +4859,9 @@ public final class Bttl_800d {
     //LAB_800de3e4
   }
 
+  /**
+   * used renderCtmd
+   */
   @Method(0x800de3f4L)
   public static void FUN_800de3f4(final TmdObjTable1c a0, final EffectManagerData6cInner a1, final MATRIX a2) {
     final int s0 = deffManager_800c693c.flags_20 & 0x4;
@@ -4891,7 +4897,7 @@ public final class Bttl_800d {
       zShift_1f8003c4.set(2);
       zMax_1f8003cc.set(0xffe);
       zMin = 0xb;
-      Renderer.renderDobj2(dobj2, false);
+      Renderer.renderDobj2(dobj2, false, 0x20);
       zShift_1f8003c4.set(oldZShift);
       zMax_1f8003cc.set(oldZMax);
       zMin = oldZMin;

--- a/src/main/java/legend/game/combat/Bttl_800e.java
+++ b/src/main/java/legend/game/combat/Bttl_800e.java
@@ -3123,9 +3123,7 @@ public final class Bttl_800e {
   @Method(0x800ec258L)
   public static void FUN_800ec258(final Model124 model) {
     final Model124 s2 = model_800bda10;
-    if(model.name.contains("file 8")) {
-      int a = 0;
-    }
+
     GsInitCoordinate2(model.coord2_14, s2.coord2_14);
 
     if(model.movementType_cc == 3) {

--- a/src/main/java/legend/game/combat/Bttl_800e.java
+++ b/src/main/java/legend/game/combat/Bttl_800e.java
@@ -3123,7 +3123,9 @@ public final class Bttl_800e {
   @Method(0x800ec258L)
   public static void FUN_800ec258(final Model124 model) {
     final Model124 s2 = model_800bda10;
-
+    if(model.name.contains("file 8")) {
+      int a = 0;
+    }
     GsInitCoordinate2(model.coord2_14, s2.coord2_14);
 
     if(model.movementType_cc == 3) {
@@ -3173,7 +3175,7 @@ public final class Bttl_800e {
     CPU.CTC2(sp0x10.transfer.getX(), 5);
     CPU.CTC2(sp0x10.transfer.getY(), 6);
     CPU.CTC2(sp0x10.transfer.getZ(), 7);
-    Renderer.renderDobj2(s2.ObjTable_0c.top[0], true);
+    Renderer.renderDobj2(s2.ObjTable_0c.top[0], true, 0);
     s2.coord2ArrPtr_04[0].flg--;
   }
 
@@ -3218,7 +3220,7 @@ public final class Bttl_800e {
         CPU.CTC2(ls.transfer.getX(), 5);
         CPU.CTC2(ls.transfer.getY(), 6);
         CPU.CTC2(ls.transfer.getZ(), 7);
-        Renderer.renderDobj2(dobj2, true);
+        Renderer.renderDobj2(dobj2, true, 0);
       }
 
       //LAB_800ec608
@@ -3344,7 +3346,7 @@ public final class Bttl_800e {
         CPU.CTC2(sp0x10.transfer.getX(), 5);
         CPU.CTC2(sp0x10.transfer.getY(), 6);
         CPU.CTC2(sp0x10.transfer.getZ(), 7);
-        Renderer.renderDobj2(s2, true);
+        Renderer.renderDobj2(s2, true, 0);
       }
     }
 

--- a/src/main/java/legend/game/combat/SEffe.java
+++ b/src/main/java/legend/game/combat/SEffe.java
@@ -8174,13 +8174,11 @@ public final class SEffe {
     a0._10.colour_1c.setX(a1._0c.getX() >> 8 & 0xff);
     a0._10.colour_1c.setY(a1._0c.getY() >> 8 & 0xff);
     a0._10.colour_1c.setZ(a1._0c.getZ() >> 8 & 0xff);
-    if(a0.name.contains("file 8")) {
-      int a = 0;
-    }
+
     if(a1._32 != -1) {
       a1._32--;
 
-      if(a1._32 << 0x10 <= 0) {
+      if(a1._32 <= 0) {
         return 0;
       }
     }
@@ -9657,9 +9655,7 @@ public final class SEffe {
   @Method(0x8011826cL)
   public static void renderDeffTmd(final ScriptState<EffectManagerData6c> state, final EffectManagerData6c data) {
     final DeffTmdRenderer14 s1 = (DeffTmdRenderer14)data.effect_44;
-    if(state.name.contains("file 8")) {
-      int x = 0;
-    }
+
     if(data._10.flags_00 >= 0) {
       final MATRIX sp0x10 = new MATRIX();
       FUN_800e8594(sp0x10, data);
@@ -9730,9 +9726,7 @@ public final class SEffe {
       final DeffPart.TmdType tmdType = (DeffPart.TmdType)getDeffPart(s1 | 0x300_0000);
       name = tmdType.name;
     }
-    if(name.contains("DEFF index 5")) {
-      int z = 0;
-    }
+
     final ScriptState<EffectManagerData6c> state = allocateEffectManager(
       "DEFF TMD " + name,
       script.scriptState_04,

--- a/src/main/java/legend/game/combat/SEffe.java
+++ b/src/main/java/legend/game/combat/SEffe.java
@@ -1065,6 +1065,9 @@ public final class SEffe {
     // no-op
   }
 
+  /**
+   * used renderCtmd
+   */
   @Method(0x800fcf20L)
   public static void FUN_800fcf20(final EffectManagerData6c a0, final TmdObjTable1c tmd, final long a2, final int tpage) {
     if(MEMORY.ref(4, a2).offset(0x0L).getSigned() >= 0) {
@@ -1104,7 +1107,7 @@ public final class SEffe {
       zShift_1f8003c4.set(2);
       zMax_1f8003cc.set(0xffe);
       zMin = 0xb;
-      Renderer.renderDobj2(sp0x60, false);
+      Renderer.renderDobj2(sp0x60, false, 0x20);
       zShift_1f8003c4.set(oldZShift);
       zMax_1f8003cc.set(oldZMax);
       zMin = oldZMin;
@@ -6578,6 +6581,9 @@ public final class SEffe {
     //LAB_8010f31c
   }
 
+  /**
+   * used renderCtmd
+   */
   @Method(0x8010f340L)
   public static void FUN_8010f340(final ScriptState<EffectManagerData6c> state, final EffectManagerData6c manager) {
     final BttlScriptData6cSub20_2 effect = (BttlScriptData6cSub20_2)manager.effect_44;
@@ -6644,16 +6650,16 @@ public final class SEffe {
 
           if(s3._01) {
             sp0xf8.tmd_08 = s3.objTable_98;
-            Renderer.renderDobj2(sp0xf8, false);
+            Renderer.renderDobj2(sp0xf8, false, 0x20);
           }
 
           //LAB_8010f5d0
           if(s3._a2 < 9) {
             sp0xf8.tmd_08 = s3.objTable_94;
-            Renderer.renderDobj2(sp0xf8, false);
+            Renderer.renderDobj2(sp0xf8, false, 0x20);
           } else if(s3._a2 >= 11) {
             sp0xf8.tmd_08 = s3.objTable_9c;
-            Renderer.renderDobj2(sp0xf8, false);
+            Renderer.renderDobj2(sp0xf8, false, 0x20);
           }
 
           zShift_1f8003c4.set(oldZShift);
@@ -7966,26 +7972,26 @@ public final class SEffe {
     return FlowControl.CONTINUE;
   }
 
+  /* calculate scale growth */
   @Method(0x80113ba0L)
   public static int FUN_80113ba0(final EffectManagerData6c data, final BttlScriptData6cSub34 sub) {
     sub._18.add(sub._24);
     sub._0c.add(sub._18);
     data._10.scale_16.set(sub._0c);
+    if(sub._32 != -1) {
+      sub._32--;
 
-    if(sub._32 == -1) {
-      return 1;
+      if(sub._32 <= 0) {
+        return 0;
+      }
     }
 
-    sub._32--;
-    if(sub._32 > 0) {
-      //LAB_80113c60
-      return 1;
-    }
-
+    //LAB_80113c60
     //LAB_80113c64
-    return 0;
+    return 1;
   }
 
+  /* set some kind of scale thing */
   @Method(0x80113c6cL)
   public static FlowControl FUN_80113c6c(final RunningScript<?> script) {
     final EffectManagerData6c s0 = (EffectManagerData6c)scriptStatePtrArr_800bc1c0[script.params_20[0].get()].innerStruct_00;
@@ -8160,6 +8166,7 @@ public final class SEffe {
     return FlowControl.CONTINUE;
   }
 
+  /* calculate color(?) scale growth */
   @Method(0x801146fcL)
   public static int FUN_801146fc(final EffectManagerData6c a0, final BttlScriptData6cSub34 a1) {
     a1._18.add(a1._24);
@@ -8167,11 +8174,13 @@ public final class SEffe {
     a0._10.colour_1c.setX(a1._0c.getX() >> 8 & 0xff);
     a0._10.colour_1c.setY(a1._0c.getY() >> 8 & 0xff);
     a0._10.colour_1c.setZ(a1._0c.getZ() >> 8 & 0xff);
-
+    if(a0.name.contains("file 8")) {
+      int a = 0;
+    }
     if(a1._32 != -1) {
       a1._32--;
 
-      if(a1._32 <= 0) {
+      if(a1._32 << 0x10 <= 0) {
         return 0;
       }
     }
@@ -8186,6 +8195,7 @@ public final class SEffe {
     throw new RuntimeException("Not implemented");
   }
 
+  /* set color scale and growth factors */
   @Method(0x80114920L)
   public static FlowControl FUN_80114920(final RunningScript<?> script) {
     final int scriptIndex1 = script.params_20[0].get();
@@ -8807,6 +8817,10 @@ public final class SEffe {
     return FlowControl.CONTINUE;
   }
 
+  /**
+   * TODO used for rendering deffs of some kind, possibly sprite deffs?
+   *   Uses CTMD render pipeline if type == 0x300_0000
+   */
   @Method(0x8011619cL)
   public static void FUN_8011619c(final EffectManagerData6c manager, final BttlScriptData6cSub5c effect, final int deffFlags, final MATRIX matrix) {
     final MATRIX sp0x10 = new MATRIX();
@@ -9639,11 +9653,13 @@ public final class SEffe {
     return FlowControl.CONTINUE;
   }
 
-  /** TODO renders other effects too? Burnout, more? */
+  /** TODO renders other effects too? Burnout, more? Uses CTMD render pipeline */
   @Method(0x8011826cL)
   public static void renderDeffTmd(final ScriptState<EffectManagerData6c> state, final EffectManagerData6c data) {
     final DeffTmdRenderer14 s1 = (DeffTmdRenderer14)data.effect_44;
-
+    if(state.name.contains("file 8")) {
+      int x = 0;
+    }
     if(data._10.flags_00 >= 0) {
       final MATRIX sp0x10 = new MATRIX();
       FUN_800e8594(sp0x10, data);
@@ -9683,7 +9699,7 @@ public final class SEffe {
         zShift_1f8003c4.set(2);
         zMax_1f8003cc.set(0xffe);
         zMin = 0xb;
-        Renderer.renderDobj2(dobj2, false);
+        Renderer.renderDobj2(dobj2, false, 0);
         zShift_1f8003c4.set(oldZShift);
         zMax_1f8003cc.set(oldZMax);
         zMin = oldZMin;
@@ -9714,7 +9730,9 @@ public final class SEffe {
       final DeffPart.TmdType tmdType = (DeffPart.TmdType)getDeffPart(s1 | 0x300_0000);
       name = tmdType.name;
     }
-
+    if(name.contains("DEFF index 5")) {
+      int z = 0;
+    }
     final ScriptState<EffectManagerData6c> state = allocateEffectManager(
       "DEFF TMD " + name,
       script.scriptState_04,
@@ -9726,7 +9744,7 @@ public final class SEffe {
     );
 
     final EffectManagerData6c manager = state.innerStruct_00;
-    manager.flags_04 |= 0x300_0000;
+    manager.flags_04 = 0x300_0000;
 
     final DeffTmdRenderer14 effect = (DeffTmdRenderer14)manager.effect_44;
 
@@ -9836,6 +9854,7 @@ public final class SEffe {
     //LAB_80118780
   }
 
+  /** TODO renders some kind of deff tmd maybe, uses ctmd render pipeline */
   @Method(0x80118790L)
   public static void FUN_80118790(final ScriptState<EffectManagerData6c> state, final EffectManagerData6c manager) {
     if(manager._10.flags_00 >= 0) {
@@ -9994,6 +10013,7 @@ public final class SEffe {
     return FlowControl.CONTINUE;
   }
 
+  /** TODO some effects use CTMD render pipeline if type == 0x300_0000 */
   @Method(0x80118e98L)
   public static void FUN_80118e98(final ScriptState<EffectManagerData6c> state, final EffectManagerData6c manager) {
     final VECTOR sp0x84 = new VECTOR();

--- a/src/main/java/legend/game/tmd/Renderer.java
+++ b/src/main/java/legend/game/tmd/Renderer.java
@@ -28,9 +28,7 @@ public final class Renderer {
     final TmdObjTable1c objTable = dobj2.tmd_08;
     final SVECTOR[] vertices = objTable.vert_top_00;
     final SVECTOR[] normals = objTable.normal_top_08;
-    if((dobj2.attribute_00 & 0x4000_0000) != 0) {
-      int x = 0;
-    }
+
     // CTMD flag and scripted "uniform lighting" + transparency flag for STMDs in DEFFs
     final int specialFlags = ctmdFlag | ((dobj2.attribute_00 & 0x4000_0000) != 0 ? 0x12 : 0x0);
 

--- a/src/main/java/legend/game/tmd/Renderer.java
+++ b/src/main/java/legend/game/tmd/Renderer.java
@@ -24,33 +24,39 @@ public final class Renderer {
   /**
    * @param useSpecialTranslucency Used in battle, some TMDs have translucency info in the upper 16 bits of their ID. Also enables backside culling.
    */
-  public static void renderDobj2(final GsDOBJ2 dobj2, final boolean useSpecialTranslucency) {
+  public static void renderDobj2(final GsDOBJ2 dobj2, final boolean useSpecialTranslucency, final int ctmdFlag) {
     final TmdObjTable1c objTable = dobj2.tmd_08;
     final SVECTOR[] vertices = objTable.vert_top_00;
     final SVECTOR[] normals = objTable.normal_top_08;
+    if((dobj2.attribute_00 & 0x4000_0000) != 0) {
+      int x = 0;
+    }
+    // CTMD flag and scripted "uniform lighting" + transparency flag for STMDs in DEFFs
+    final int specialFlags = ctmdFlag | ((dobj2.attribute_00 & 0x4000_0000) != 0 ? 0x12 : 0x0);
 
     //LAB_800da2bc
     for(final TmdObjTable1c.Primitive primitive : objTable.primitives_10) {
-      renderTmdPrimitive(primitive, vertices, normals, useSpecialTranslucency);
+      renderTmdPrimitive(primitive, vertices, normals, useSpecialTranslucency, specialFlags);
     }
   }
 
-  public static void renderTmdPrimitive(final TmdObjTable1c.Primitive primitive, final SVECTOR[] vertices, final SVECTOR[] normals, final boolean useSpecialTranslucency) {
+  public static void renderTmdPrimitive(final TmdObjTable1c.Primitive primitive, final SVECTOR[] vertices, final SVECTOR[] normals, final boolean useSpecialTranslucency, final int specialFlags) {
     // Read type info from command ---
-    final int command = primitive.header() & 0xff04_0000;
+    final int command = (primitive.header() | specialFlags) & 0xff04_0000;
     final int primitiveId = command >>> 24;
-
     if((primitiveId >>> 5 & 0b11) != 1) {
       throw new RuntimeException("Unsupported primitive type");
     }
 
-    final boolean gradated = (command & 0x4_0000) != 0;
+    final boolean ctmd = (specialFlags & 0x20) != 0;
+    final boolean uniformLit = (specialFlags & 0x10) != 0;
+    final boolean shaded = (command & 0x4_0000) != 0;
     final boolean quad = (primitiveId & 0b1000) != 0;
     final boolean textured = (primitiveId & 0b100) != 0;
-    final boolean translucent = (primitiveId & 0b10) != 0;
+    final boolean translucent = ((primitiveId & 0b10) != 0) || ((specialFlags & 0x2) != 0);
     final boolean lit = (primitiveId & 0b1) == 0;
 
-    if(textured && gradated) {
+    if(textured && shaded) {
       throw new RuntimeException("Invalid primitive type");
     }
 
@@ -86,7 +92,7 @@ public final class Renderer {
         }
       }
 
-      if(gradated || !lit) {
+      if(shaded || !lit) {
         for(int vertexIndex = 0; vertexIndex < vertexCount; vertexIndex++) {
           poly.vertices[vertexIndex].colour = IoHelper.readInt(data, primitivesOffset);
           primitivesOffset += 4;
@@ -167,11 +173,20 @@ public final class Renderer {
         continue;
       }
 
-      if(textured && !lit) {
+      if(translucent && (ctmd || uniformLit)) {
+        final long rbk = CPU.CFC2(13);
+        final long gbk = CPU.CFC2(14);
+        final long bbk = CPU.CFC2(15);
+
         for(int vertexIndex = 0; vertexIndex < vertexCount; vertexIndex++) {
-          cmd.rgb(vertexIndex, poly.vertices[vertexIndex].colour);
+          int rgb = poly.vertices[vertexIndex].colour;
+          final int r = (int)((((rgb >>> 16) & 0xff) * rbk >> 0xc) & 0xff);
+          final int g = (int)((((rgb >>> 8) & 0xff) * gbk >> 0xc) & 0xff);
+          final int b = (int)(((rgb & 0xff) * bbk >> 0xc) & 0xff);
+          rgb = r << 16 | g << 8 | b;
+          cmd.rgb(vertexIndex, rgb);
         }
-      } else {
+      } else if(!textured || lit) {
         for(int vertexIndex = 0; vertexIndex < vertexCount; vertexIndex++) {
           CPU.MTC2(poly.vertices[vertexIndex].colour, 6);
 
@@ -183,9 +198,13 @@ public final class Renderer {
           }
 
           CPU.MTC2(norm.getXY(), 0);
-          CPU.MTC2(norm.getZ(),  1);
+          CPU.MTC2(norm.getZ(), 1);
           CPU.COP2(0x108_041bL); // Normal colour colour single vector
           cmd.rgb(vertexIndex, (int)CPU.MFC2(22));
+        }
+      } else {
+        for(int vertexIndex = 0; vertexIndex < vertexCount; vertexIndex++) {
+          cmd.rgb(vertexIndex, poly.vertices[vertexIndex].colour);
         }
       }
 

--- a/src/main/java/legend/game/tmd/Renderer.java
+++ b/src/main/java/legend/game/tmd/Renderer.java
@@ -180,10 +180,10 @@ public final class Renderer {
 
         for(int vertexIndex = 0; vertexIndex < vertexCount; vertexIndex++) {
           int rgb = poly.vertices[vertexIndex].colour;
-          final int r = (int)((((rgb >>> 16) & 0xff) * rbk >> 0xc) & 0xff);
-          final int g = (int)((((rgb >>> 8) & 0xff) * gbk >> 0xc) & 0xff);
-          final int b = (int)(((rgb & 0xff) * bbk >> 0xc) & 0xff);
-          rgb = r << 16 | g << 8 | b;
+          final int r = (int)(((rgb & 0xff) * rbk >> 12) & 0xff);
+          final int g = (int)((((rgb >>> 8) & 0xff) * gbk >> 12) & 0xff);
+          final int b = (int)((((rgb >>> 16) & 0xff) * bbk >> 12) & 0xff);
+          rgb = b << 16 | g << 8 | r;
           cmd.rgb(vertexIndex, rgb);
         }
       } else if(!textured || lit) {


### PR DESCRIPTION
This PR mainly fixes issues in the universal renderer where certain effects need to have uniform lighting applied, which was originally done in the CTMD renderers when certain flags were set (CTMD primitive flag and `dobj.attribute_00 == 0x4000_0000`).

Aside from that, I also fixed a small flag issue in allocateDeffTmd (a line was supposed to be `= 0x300_0000`, not `|= 0x300_0000`, see 80118554 in ghidra), and changed how 80113ba0 was ordered to match 801146fc, which appears to be an equivalent function for a different transformation metric. These changes are related to some of the fixed effects (like mouse's bite) as well, dealing with the transformation of these deff effects.
