### PR TITLE
Fixed lighting on LSC translucent textured prims

### DIFF
--- a/src/main/java/legend/game/tmd/Renderer.java
+++ b/src/main/java/legend/game/tmd/Renderer.java
@@ -173,7 +173,7 @@ public final class Renderer {
         continue;
       }
 
-      if(textured && translucent && (ctmd || uniformLit)) {
+      if(textured && translucent && !lit && (ctmd || uniformLit)) {
         final BattleLightStruct64 bkLight = _800c6930;
         final int rbk = bkLight.colour_00.getX();
         final int gbk = bkLight.colour_00.getY();


### PR DESCRIPTION
Needed to explicitly exclude lit primitives from the uniform lighting logic branch.

Don't know how many things this affected, but Lavitz's damaged chest plate during oof is an example, now correct.