### PR TITLE
Game Speed Multiplier

### DIFF
--- a/src/main/java/legend/core/Config.java
+++ b/src/main/java/legend/core/Config.java
@@ -30,6 +30,7 @@ public final class Config {
     properties.setProperty("battle_ui_r", "0");
     properties.setProperty("battle_ui_g", "41");
     properties.setProperty("battle_ui_b", "159");
+    properties.setProperty("game_speed_multiplier", "1");
     properties.setProperty("save_anywhere", "false");
     properties.setProperty("auto_addition", "false");
     properties.setProperty("auto_dragoon_meter", "false");
@@ -118,6 +119,14 @@ public final class Config {
 
   public static void setCombatStage(final int id) {
     properties.setProperty("combat_stage_id", String.valueOf(id));
+  }
+
+  public static int getGameSpeedMultiplier() {
+    return readInt("game_speed_multiplier", 1, 1, 16);
+  }
+
+  public static void setGameSpeedMultiplier(final int id) {
+    properties.setProperty("game_speed_multiplier", String.valueOf(id));
   }
 
   public static  boolean fastTextSpeed() {

--- a/src/main/java/legend/game/Scus94491BpeSegment.java
+++ b/src/main/java/legend/game/Scus94491BpeSegment.java
@@ -483,7 +483,7 @@ public final class Scus94491BpeSegment {
       }
 
       final int frames = Math.max(1, vsyncMode_8007a3b8.get());
-      GPU.window().setFpsLimit(60 / frames);
+      GPU.window().setFpsLimit((60 / frames) * Config.getGameSpeedMultiplier());
 
       startFrame();
       tickDeferredReallocOrFree();

--- a/src/main/java/legend/game/Scus94491BpeSegment.java
+++ b/src/main/java/legend/game/Scus94491BpeSegment.java
@@ -238,6 +238,9 @@ import static legend.game.combat.SBtld.stageData_80109a98;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_DELETE;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_F11;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_F12;
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_MINUS;
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_EQUAL;
+
 
 public final class Scus94491BpeSegment {
   private Scus94491BpeSegment() { }
@@ -427,6 +430,15 @@ public final class Scus94491BpeSegment {
 
   @Method(0x80011e1cL)
   public static void gameLoop() {
+    GPU.events().onKeyRepeat((window, key, scancode, mods) -> {
+      if(key == GLFW_KEY_EQUAL) {
+        Config.setGameSpeedMultiplier(Config.getGameSpeedMultiplier() + 1);
+      }
+
+      if(key == GLFW_KEY_MINUS) {
+        Config.setGameSpeedMultiplier(Config.getGameSpeedMultiplier() - 1);
+      }
+    });
     GPU.events().onKeyPress((window, key, scancode, mods) -> {
       // Add killswitch in case sounds get stuck on
       if(key == GLFW_KEY_DELETE) {
@@ -446,6 +458,14 @@ public final class Scus94491BpeSegment {
         }
       }
 
+      if(key == GLFW_KEY_EQUAL) {
+        Config.setGameSpeedMultiplier(Config.getGameSpeedMultiplier() + 1);
+      }
+
+      if(key == GLFW_KEY_MINUS) {
+        Config.setGameSpeedMultiplier(Config.getGameSpeedMultiplier() - 1);
+      }
+      
       if(key == GLFW_KEY_F12) {
         if(!Debugger.isRunning()) {
           try {

--- a/src/main/java/legend/game/Scus94491BpeSegment.java
+++ b/src/main/java/legend/game/Scus94491BpeSegment.java
@@ -241,7 +241,6 @@ import static org.lwjgl.glfw.GLFW.GLFW_KEY_F12;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_MINUS;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_EQUAL;
 
-
 public final class Scus94491BpeSegment {
   private Scus94491BpeSegment() { }
 
@@ -465,7 +464,7 @@ public final class Scus94491BpeSegment {
       if(key == GLFW_KEY_MINUS) {
         Config.setGameSpeedMultiplier(Config.getGameSpeedMultiplier() - 1);
       }
-      
+
       if(key == GLFW_KEY_F12) {
         if(!Debugger.isRunning()) {
           try {

--- a/src/main/java/legend/game/Scus94491BpeSegment.java
+++ b/src/main/java/legend/game/Scus94491BpeSegment.java
@@ -6,6 +6,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import javafx.application.Application;
 import javafx.application.Platform;
+import legend.core.Config;
 import legend.core.DebugHelper;
 import legend.core.MathHelper;
 import legend.core.gpu.Bpp;

--- a/src/main/java/legend/game/debugger/DebuggerController.java
+++ b/src/main/java/legend/game/debugger/DebuggerController.java
@@ -199,7 +199,7 @@ public class DebuggerController {
 
   @FXML
   private void getGameSpeedMultiplier(final ActionEvent event) {
-    Config.getGameSpeedMultiplier();
+    this.gameSpeedMultiplier.getValueFactory().setValue(Config.getGameSpeedMultiplier());
   }
 
   @FXML

--- a/src/main/java/legend/game/debugger/DebuggerController.java
+++ b/src/main/java/legend/game/debugger/DebuggerController.java
@@ -63,6 +63,13 @@ public class DebuggerController {
   public Button setVsyncMode;
 
   @FXML
+  public Spinner<Integer> gameSpeedMultiplier;
+  @FXML
+  public Button getGameSpeedMultiplier;
+  @FXML
+  public Button setGameSpeedMultiplier;
+
+  @FXML
   public CheckBox battleUiColour;
   @FXML
   public Spinner<Integer> battleUIColourR;
@@ -91,6 +98,7 @@ public class DebuggerController {
     this.encounterId.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(0, Integer.MAX_VALUE, 0));
     this.mapId.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(0, Integer.MAX_VALUE, 0));
     this.vsyncMode.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(1, Integer.MAX_VALUE, 1));
+    this.gameSpeedMultiplier.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(1, 16, Config.getGameSpeedMultiplier()));
     this.battleUiColour.setSelected(Config.changeBattleRGB());
     this.saveAnywhere.setSelected(Config.saveAnywhere());
     this.battleUIColourR.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(0, 255, (Config.getBattleRGB() & 0xff)));
@@ -187,6 +195,16 @@ public class DebuggerController {
   @FXML
   private void setVsyncMode(final ActionEvent event) {
     vsyncMode_8007a3b8.set(this.vsyncMode.getValue());
+  }
+
+  @FXML
+  private void getGameSpeedMultiplier(final ActionEvent event) {
+    Config.getGameSpeedMultiplier();
+  }
+
+  @FXML
+  private void setGameSpeedMultiplier(final ActionEvent event) {
+    Config.setGameSpeedMultiplier(this.gameSpeedMultiplier.getValue());
   }
 
   @FXML

--- a/src/main/resources/legend/game/debugger/debugger.fxml
+++ b/src/main/resources/legend/game/debugger/debugger.fxml
@@ -64,6 +64,14 @@
                   <Button fx:id="setVsyncMode" mnemonicParsing="false" onAction="#setVsyncMode" text="Set" />
                </children>
             </HBox>
+            <Label text="Game Speed Multiplier" />
+            <HBox prefHeight="0.0" prefWidth="193.0">
+               <children>
+                  <Spinner fx:id="gameSpeedMultiplier" editable="true" prefHeight="26.0" prefWidth="90.0" />
+                  <Button fx:id="getGameSpeedMultiplier" mnemonicParsing="false" onAction="#getGameSpeedMultiplier" text="Get" />
+                  <Button fx:id="setGameSpeedMultiplier" mnemonicParsing="false" onAction="#setGameSpeedMultiplier" text="Set" />
+               </children>
+            </HBox>
             <CheckBox fx:id="saveAnywhere" mnemonicParsing="false" onAction="#toggleSaveAnywhere" text="Save Anywhere" />
             <CheckBox fx:id="fastTextSpeed" mnemonicParsing="false" onAction="#toggleFastText" text="Fast Text Speed" />
             <CheckBox fx:id="autoAdvanceText" mnemonicParsing="false" onAction="#toggleAutoAdvanceText" text="Auto Advance Text" />


### PR DESCRIPTION
### Description
Adds a game speed multiplier to the debugger and to direct keyboard support with - and = keys.

### Controls
The keyboard controls both require checks in the .onKeyPress and .onKeyRepeat in the GPU gameLoop() to receive nice behaviour with the - and = inputs. Not sure what other way to do this is better.

### Inline Save
Think we should limit this to debug-focused purpose first before implementing it in the config option being saved in save files, if applicable. Iron out use-cases and/or bugs. Other considerations like game play integrity of saves is a discussion.

### main
Is this going on on main?

### Issue 1
Initial loading screen effects are slowed down inversely to the multiplier (fade in, fade out). The menu or game is still fully playable...you just may not be able to see anything for 1-3 seconds.

VSync settings are hardcoded in multiple places.

### Issue 2
VSync is bugged on its own and not related to anything I've changed in the debugger.

### Issue 3
Don't see a way to make text display faster that is not a headache.