### PR TITLE
Back-face culling now always used when rendering TMDs

### DIFF
--- a/src/main/java/legend/game/tmd/Renderer.java
+++ b/src/main/java/legend/game/tmd/Renderer.java
@@ -147,15 +147,17 @@ public final class Renderer {
           cmd.uv(vertexIndex, poly.vertices[vertexIndex].u, poly.vertices[vertexIndex].v);
         }
 
-        // Back-face culling
-        if(useSpecialTranslucency) {
-          if(vertexIndex == 2) {
-            CPU.COP2(0x140_0006L); // Normal clipping
-            final long winding = CPU.MFC2(24);
+        /* if(useSpecialTranslucency) {
+          TODO Figure out how specialTrans is used
+        } */
 
-            if(!translucent && winding <= 0 || translucent && winding == 0) {
-              continue outer;
-            }
+        // Back-face culling
+        if(vertexIndex == 2) {
+          CPU.COP2(0x140_0006L); // Normal clipping
+          final long winding = CPU.MFC2(24);
+
+          if(!translucent && winding <= 0 || translucent && winding == 0) {
+            continue outer;
           }
         }
       }


### PR DESCRIPTION
After looking through all of the CTMD renderers and all the STMD renderers for SMAP, BTTL, and WMAP, it appears that all TMD rendering should use back-face culling. I moved the winding and culling code out from the useSpecialTransparency check, which does not appear to be relevant to control culling, other than possibly secondarily through transparency. 

Fixed by this PR:
- #289 
- #308 
- #355 
- Normals on Albert's hands when receiving JDS
- Certain crates not rendering properly
- Probably a bunch of other stuff we haven't catalogued