### PR TITLE
Fixes sprite renderer called by processLmb methods

### DIFF
--- a/src/main/java/legend/game/combat/SEffe.java
+++ b/src/main/java/legend/game/combat/SEffe.java
@@ -8920,7 +8920,7 @@ public final class SEffe {
 
         final GpuCommandPoly cmd = new GpuCommandPoly(4)
           .clut((clut & 0b111111) * 16, clut >>> 6)
-          .vramPos(((effect.metrics_54.u_00.get() & 0x3ff) & ~0x3f), (effect.metrics_54.v_02.get() & 0x100) != 0 ? 256 : 0)
+          .vramPos(effect.metrics_54.u_00.get() & 0x3c0, (effect.metrics_54.v_02.get() & 0x100) != 0 ? 256 : 0)
           .rgb(manager._10.colour_1c.getX(), manager._10.colour_1c.getY(), manager._10.colour_1c.getZ())
           .pos(0, sp0x80.getX() + cosL - sinT, sp0x80.getY() + sinL + cosT)
           .pos(1, sp0x80.getX() + cosR - sinT, sp0x80.getY() + sinR + cosT)

--- a/src/main/java/legend/game/combat/SEffe.java
+++ b/src/main/java/legend/game/combat/SEffe.java
@@ -8920,7 +8920,7 @@ public final class SEffe {
 
         final GpuCommandPoly cmd = new GpuCommandPoly(4)
           .clut((clut & 0b111111) * 16, clut >>> 6)
-          .vramPos(effect.metrics_54.u_00.get() & 0x3ff, (effect.metrics_54.v_02.get() & 0x100) != 0 ? 256 : 0)
+          .vramPos(((effect.metrics_54.u_00.get() & 0x3ff) & ~0x3f), (effect.metrics_54.v_02.get() & 0x100) != 0 ? 256 : 0)
           .rgb(manager._10.colour_1c.getX(), manager._10.colour_1c.getY(), manager._10.colour_1c.getZ())
           .pos(0, sp0x80.getX() + cosL - sinT, sp0x80.getY() + sinL + cosT)
           .pos(1, sp0x80.getX() + cosR - sinT, sp0x80.getY() + sinR + cosT)


### PR DESCRIPTION
When constructing the gp0 packet in retail, the u value is right-shifted by 6 to fit it into the low nibble of the tpage in the packet, so the lowest 6 bytes are removed when multiplying by 64 to calculate VRAM position. u is composed of VRAM X + u, so in SC, the u needed to be factored out as well.

Fixes Melbu's solar system attack and ??? other effects.