### PR TITLE
Fix #466 (Lloyd crash)

### DIFF
--- a/src/main/java/legend/game/combat/Bttl_800e.java
+++ b/src/main/java/legend/game/combat/Bttl_800e.java
@@ -1565,14 +1565,14 @@ public final class Bttl_800e {
       final int y = MathHelper.safeDiv(sp0x18.getY() * projectionPlaneDistance_1f8003f8.get(), sp0x18.getZ());
 
       // a2 needs to be ignored in z check or poly positions will overflow at low z values
-      int z = sp0x18.getZ() >> 2;
-      if(z >= 0x28) {
+      int z = a2 + (sp0x18.getZ() >> 2);
+      if(sp0x18.getZ() >> 2 >= 0x28) {
         if(z > 0x3ff8) {
           z = 0x3ff8;
         }
 
         //LAB_800e7a38
-        final int a1 = MathHelper.safeDiv(projectionPlaneDistance_1f8003f8.get() << 10, z);
+        final int a1 = MathHelper.safeDiv(projectionPlaneDistance_1f8003f8.get() << 10, sp0x18.getZ() >> 2);
         final int s5 = s1.x_04.get() * s1.scaleX_1c.get() / 8 * a1 / 8 >> 12;
         final int s7 = s5 + (s1.w_08.get() * s1.scaleX_1c.get() / 8 * a1 / 8 >> 12);
         final int s2 = s1.y_06.get() * s1.scaleY_1e.get() / 8 * a1 / 8 >> 12;
@@ -1597,7 +1597,7 @@ public final class Bttl_800e {
           cmd.translucent(Translucency.of((int)s1.flags_00.get() >>> 28 & 0b11));
         }
 
-        GPU.queueCommand((a2 + z) >> 2, cmd);
+        GPU.queueCommand(z >> 2, cmd);
       }
     }
 

--- a/src/main/java/legend/game/combat/Bttl_800e.java
+++ b/src/main/java/legend/game/combat/Bttl_800e.java
@@ -1564,7 +1564,7 @@ public final class Bttl_800e {
       final int x = MathHelper.safeDiv(sp0x18.getX() * projectionPlaneDistance_1f8003f8.get(), sp0x18.getZ());
       final int y = MathHelper.safeDiv(sp0x18.getY() * projectionPlaneDistance_1f8003f8.get(), sp0x18.getZ());
 
-      // a2 needs to be ignored in z check or
+      // a2 needs to be ignored in z check or poly positions will overflow at low z values
       int z = sp0x18.getZ() >> 2;
       if(z >= 0x28) {
         if(z > 0x3ff8) {

--- a/src/main/java/legend/game/combat/Bttl_800e.java
+++ b/src/main/java/legend/game/combat/Bttl_800e.java
@@ -21,6 +21,7 @@ import legend.core.memory.Ref;
 import legend.core.memory.Value;
 import legend.core.memory.types.IntRef;
 import legend.core.memory.types.MemoryRef;
+import legend.game.combat.bobj.BattleObject27c;
 import legend.game.combat.bobj.MonsterBattleObject;
 import legend.game.combat.bobj.PlayerBattleObject;
 import legend.game.combat.deff.Anim;
@@ -44,7 +45,6 @@ import legend.game.combat.environment.BattleStruct14;
 import legend.game.combat.environment.BttlLightStruct84;
 import legend.game.combat.environment.BttlLightStruct84Sub38;
 import legend.game.combat.environment.StageAmbiance4c;
-import legend.game.combat.bobj.BattleObject27c;
 import legend.game.combat.types.BattleScriptDataBase;
 import legend.game.combat.types.CombatantStruct1a8;
 import legend.game.combat.types.MonsterStats1c;
@@ -1564,14 +1564,15 @@ public final class Bttl_800e {
       final int x = MathHelper.safeDiv(sp0x18.getX() * projectionPlaneDistance_1f8003f8.get(), sp0x18.getZ());
       final int y = MathHelper.safeDiv(sp0x18.getY() * projectionPlaneDistance_1f8003f8.get(), sp0x18.getZ());
 
-      int z = a2 + (sp0x18.getZ() >> 2);
+      // a2 needs to be ignored in z check or
+      int z = sp0x18.getZ() >> 2;
       if(z >= 0x28) {
         if(z > 0x3ff8) {
           z = 0x3ff8;
         }
 
         //LAB_800e7a38
-        final int a1 = MathHelper.safeDiv(projectionPlaneDistance_1f8003f8.get() << 10, sp0x18.getZ() >> 2);
+        final int a1 = MathHelper.safeDiv(projectionPlaneDistance_1f8003f8.get() << 10, z);
         final int s5 = s1.x_04.get() * s1.scaleX_1c.get() / 8 * a1 / 8 >> 12;
         final int s7 = s5 + (s1.w_08.get() * s1.scaleX_1c.get() / 8 * a1 / 8 >> 12);
         final int s2 = s1.y_06.get() * s1.scaleY_1e.get() / 8 * a1 / 8 >> 12;
@@ -1596,7 +1597,7 @@ public final class Bttl_800e {
           cmd.translucent(Translucency.of((int)s1.flags_00.get() >>> 28 & 0b11));
         }
 
-        GPU.queueCommand(z >> 2, cmd);
+        GPU.queueCommand((a2 + z) >> 2, cmd);
       }
     }
 


### PR DESCRIPTION
The energy blast effects were still being rendered very close to the camera, causing pixel coordinates to overflow.