### PR TITLE
Fixes issues with some normals

### DIFF
--- a/src/main/java/legend/game/tmd/Renderer.java
+++ b/src/main/java/legend/game/tmd/Renderer.java
@@ -194,7 +194,7 @@ public final class Renderer {
           CPU.MTC2(poly.vertices[vertexIndex].colour, 6);
 
           final SVECTOR norm;
-          if(vertexIndex < normals.length) {
+          if(poly.vertices[vertexIndex].normalIndex < normals.length) {
             norm = normals[poly.vertices[vertexIndex].normalIndex];
           } else {
             norm = new SVECTOR();


### PR DESCRIPTION
TMD normals were not being used for vertices that exceeded the number of normals (so quads from objects with 3 or fewer normals or triangles from objects with 2 or fewer). Corrected so that the normal index of a vertex is compared against the number of normals. This probably fixes a several things, but most noticeably it fixes Albert's cape.

![image](https://github.com/Legend-of-Dragoon-Modding/Legend-of-Dragoon-Java/assets/55669985/c3baeaef-a501-4c35-9c4b-7b0114fbefb8)
