### PR TITLE
Adds virtualSize to FileData

### DIFF
--- a/src/main/java/legend/game/SItem.java
+++ b/src/main/java/legend/game/SItem.java
@@ -397,7 +397,7 @@ public final class SItem {
 
         //LAB_800fc464
         for(int enemySlot = 0; enemySlot < 3; enemySlot++) {
-          if((s2.encounterData_00.enemyIndices_00[enemySlot] & 0x1ff) == enemyIndex && files.get(enemySlot).real()) {
+          if((s2.encounterData_00.enemyIndices_00[enemySlot] & 0x1ff) == enemyIndex && files.get(enemySlot).hasVirtualSize()) {
             loadCombatantTim(i, files.get(enemySlot));
             break;
           }

--- a/src/main/java/legend/game/SMap.java
+++ b/src/main/java/legend/game/SMap.java
@@ -2714,7 +2714,7 @@ public final class SMap {
             final SubmapObject obj = new SubmapObject();
             obj.script = new ScriptFile("Submap object %d (DRGN%d/%d/%d)".formatted(objIndex, drgnIndex.get(), fileIndex.get() + 2, objIndex + 1), scriptData);
 
-            if(submapModel.real()) {
+            if(submapModel.hasVirtualSize() && submapModel.real()) {
               obj.model = new CContainer("Submap object %d (DRGN%d/%d/%d)".formatted(objIndex, drgnIndex.get(), fileIndex.get() + 1, objIndex * 33), new FileData(submapModel.getBytes()));
             } else {
               obj.model = null;

--- a/src/main/java/legend/game/combat/Bttl_800c.java
+++ b/src/main/java/legend/game/combat/Bttl_800c.java
@@ -65,7 +65,6 @@ import legend.game.combat.ui.CombatMenua4;
 import legend.game.combat.ui.FloatingNumberC4;
 import legend.game.fmv.Fmv;
 import legend.game.inventory.WhichMenu;
-import legend.game.modding.coremod.CoreMod;
 import legend.game.scripting.FlowControl;
 import legend.game.scripting.IntParam;
 import legend.game.scripting.RunningScript;
@@ -114,9 +113,9 @@ import static legend.game.Scus94491BpeSegment.loadSupportOverlay;
 import static legend.game.Scus94491BpeSegment.mallocTail;
 import static legend.game.Scus94491BpeSegment.orderingTableSize_1f8003c8;
 import static legend.game.Scus94491BpeSegment.renderMcq;
+import static legend.game.Scus94491BpeSegment.resizeDisplay;
 import static legend.game.Scus94491BpeSegment.scriptStartEffect;
 import static legend.game.Scus94491BpeSegment.setDepthResolution;
-import static legend.game.Scus94491BpeSegment.resizeDisplay;
 import static legend.game.Scus94491BpeSegment.simpleRand;
 import static legend.game.Scus94491BpeSegment_8002.FUN_80020308;
 import static legend.game.Scus94491BpeSegment_8002.FUN_80021520;
@@ -148,8 +147,6 @@ import static legend.game.Scus94491BpeSegment_8006._8006e398;
 import static legend.game.Scus94491BpeSegment_8007.clearRed_8007a3a8;
 import static legend.game.Scus94491BpeSegment_8007.joypadPress_8007a398;
 import static legend.game.Scus94491BpeSegment_8007.vsyncMode_8007a3b8;
-import static legend.game.Scus94491BpeSegment_800b.clearBlue_800babc0;
-import static legend.game.Scus94491BpeSegment_800b.clearGreen_800bb104;
 import static legend.game.Scus94491BpeSegment_800b._800bb168;
 import static legend.game.Scus94491BpeSegment_800b._800bc910;
 import static legend.game.Scus94491BpeSegment_800b._800bc914;
@@ -159,6 +156,8 @@ import static legend.game.Scus94491BpeSegment_800b._800bc960;
 import static legend.game.Scus94491BpeSegment_800b._800bc968;
 import static legend.game.Scus94491BpeSegment_800b._800bc97c;
 import static legend.game.Scus94491BpeSegment_800b.afterFmvLoadingStage_800bf0ec;
+import static legend.game.Scus94491BpeSegment_800b.clearBlue_800babc0;
+import static legend.game.Scus94491BpeSegment_800b.clearGreen_800bb104;
 import static legend.game.Scus94491BpeSegment_800b.combatStage_800bb0f4;
 import static legend.game.Scus94491BpeSegment_800b.encounterId_800bb0f8;
 import static legend.game.Scus94491BpeSegment_800b.fmvIndex_800bf0dc;
@@ -1800,7 +1799,7 @@ public final class Bttl_800c {
       if(!isMonster && files.size() == 64) {
         //LAB_800c9940
         for(int animIndex = 0; animIndex < 32; animIndex++) {
-          if(files.get(32 + animIndex).real() || files.get(32 + animIndex).virtualSize() != 0) {
+          if(files.get(32 + animIndex).real()) {
             if(combatant._14[animIndex] != null && combatant._14[animIndex]._09 != 0) {
               FUN_800c9c7c(combatantIndex, animIndex);
             }

--- a/src/main/java/legend/game/combat/Bttl_800c.java
+++ b/src/main/java/legend/game/combat/Bttl_800c.java
@@ -1409,7 +1409,7 @@ public final class Bttl_800c {
   @Method(0x800c8b20L)
   public static void loadStage(final int stage) {
     loadDrgnDir(0, 2497 + stage, files -> {
-      if(files.get(0).real()) {
+      if(files.get(0).hasVirtualSize()) {
         if(battlePreloadedEntities_1f8003f4.stageMcq_9cb0 != null) {
           free(battlePreloadedEntities_1f8003f4.stageMcq_9cb0.getAddress());
         }
@@ -1581,7 +1581,7 @@ public final class Bttl_800c {
   @Method(0x800c90b0L)
   public static long FUN_800c90b0(final int combatantIndex) {
     //LAB_800c9114
-    if((combatants_8005e398[combatantIndex]._1a4 >= 0 || combatants_8005e398[combatantIndex].mrg_00 != null && combatants_8005e398[combatantIndex].mrg_00.get(32).real()) && FUN_800ca054(combatantIndex, 0) != 0) {
+    if((combatants_8005e398[combatantIndex]._1a4 >= 0 || combatants_8005e398[combatantIndex].mrg_00 != null && combatants_8005e398[combatantIndex].mrg_00.get(32).hasVirtualSize()) && FUN_800ca054(combatantIndex, 0) != 0) {
       return 0x1L;
     }
 
@@ -1682,14 +1682,14 @@ public final class Bttl_800c {
     combatant.mrg_00 = files;
 
     // I don't think this is actually used?
-    if(files.get(34).real()) {
+    if(files.get(34).hasVirtualSize()) {
       combatant.scriptPtr_10 = new ScriptFile("%s %d file 34".formatted(isMonster ? "monster" : "char", combatant.charSlot_19c), files.get(34).getBytes());
     }
 
     //LAB_800c94a0
     //LAB_800c94a4
     for(int animIndex = 0; animIndex < 32; animIndex++) {
-      if(files.get(animIndex).real()) {
+      if(files.get(animIndex).hasVirtualSize()) {
         FUN_800c9a80(files.get(animIndex), 1, 0, combatantIndex, animIndex);
       }
 
@@ -1714,7 +1714,7 @@ public final class Bttl_800c {
       tmd = new CContainer(model.name, FUN_800cad34(s0._1a4));
     } else {
       //LAB_800c9590
-      if(s0.mrg_00 != null && s0.mrg_00.get(32).real()) {
+      if(s0.mrg_00 != null && s0.mrg_00.get(32).hasVirtualSize()) {
         tmd = new CContainer(model.name, s0.mrg_00.get(32));
       } else {
         throw new RuntimeException("anim undefined");
@@ -1799,7 +1799,7 @@ public final class Bttl_800c {
       if(!isMonster && files.size() == 64) {
         //LAB_800c9940
         for(int animIndex = 0; animIndex < 32; animIndex++) {
-          if(files.get(32 + animIndex).real()) {
+          if(files.get(32 + animIndex).hasVirtualSize()) {
             if(combatant._14[animIndex] != null && combatant._14[animIndex]._09 != 0) {
               FUN_800c9c7c(combatantIndex, animIndex);
             }
@@ -1816,7 +1816,7 @@ public final class Bttl_800c {
 
       //LAB_800c99e8
       for(int animIndex = 0; animIndex < 32; animIndex++) {
-        if(files.get(animIndex).real()) {
+        if(files.get(animIndex).hasVirtualSize()) {
           if(combatant._14[animIndex] != null && combatant._14[animIndex]._09 != 0) {
             FUN_800c9c7c(combatantIndex, animIndex);
           }

--- a/src/main/java/legend/game/combat/Bttl_800c.java
+++ b/src/main/java/legend/game/combat/Bttl_800c.java
@@ -1800,7 +1800,7 @@ public final class Bttl_800c {
       if(!isMonster && files.size() == 64) {
         //LAB_800c9940
         for(int animIndex = 0; animIndex < 32; animIndex++) {
-          if(files.get(32 + animIndex).real()) {
+          if(files.get(32 + animIndex).real() || files.get(32 + animIndex).virtualSize() != 0) {
             if(combatant._14[animIndex] != null && combatant._14[animIndex]._09 != 0) {
               FUN_800c9c7c(combatantIndex, animIndex);
             }

--- a/src/main/java/legend/game/combat/Bttl_800e.java
+++ b/src/main/java/legend/game/combat/Bttl_800e.java
@@ -2004,7 +2004,7 @@ public final class Bttl_800e {
 
     //LAB_800e92d4
     for(final FileData file : files) {
-      if(file.real()) {
+      if(file.hasVirtualSize()) {
         new Tim(file).uploadToGpu();
       }
     }
@@ -3714,7 +3714,7 @@ public final class Bttl_800e {
 
     //LAB_800ee9c0
     for(int fileIndex = 0; fileIndex < files.size(); fileIndex++) {
-      if(files.get(fileIndex).real()) {
+      if(files.get(fileIndex).hasVirtualSize()) {
         final Tim tim = new Tim(files.get(fileIndex));
 
         if(fileIndex == 0) {

--- a/src/main/java/legend/game/unpacker/FileData.java
+++ b/src/main/java/legend/game/unpacker/FileData.java
@@ -24,6 +24,10 @@ public record FileData(byte[] data, int offset, int size, int virtualSize, int r
 
   /** Not a virtual file and larger than zero bytes */
   public boolean real() {
+    return this.realFileIndex == -1 && this.size != 0;
+  }
+
+  public boolean hasVirtualSize() {
     return this.virtualSize != 0;
   }
 

--- a/src/main/java/legend/game/unpacker/FileData.java
+++ b/src/main/java/legend/game/unpacker/FileData.java
@@ -24,7 +24,7 @@ public record FileData(byte[] data, int offset, int size, int virtualSize, int r
 
   /** Not a virtual file and larger than zero bytes */
   public boolean real() {
-    return this.realFileIndex == -1 && this.size != 0;
+    return this.virtualSize != 0;
   }
 
   public FileData slice(final int offset, final int size) {

--- a/src/main/java/legend/game/unpacker/FileData.java
+++ b/src/main/java/legend/game/unpacker/FileData.java
@@ -9,17 +9,17 @@ import legend.game.modding.registries.RegistryId;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
-public record FileData(byte[] data, int offset, int size, int realFileIndex) {
-  public static FileData virtual(final FileData real, final int realFileIndex) {
-    return new FileData(real.data, real.offset, real.data.length, realFileIndex);
+public record FileData(byte[] data, int offset, int size, int virtualSize, int realFileIndex) {
+  public static FileData virtual(final FileData real, final int virtualSize, final int realFileIndex) {
+    return new FileData(real.data, real.offset, real.data.length, virtualSize, realFileIndex);
   }
 
   public FileData(final byte[] data) {
-    this(data, 0, data.length, -1);
+    this(data, 0, data.length, data.length, -1);
   }
 
   public FileData(final byte[] data, final int offset, final int size) {
-    this(data, offset, size, -1);
+    this(data, offset, size, size, -1);
   }
 
   /** Not a virtual file and larger than zero bytes */
@@ -29,7 +29,7 @@ public record FileData(byte[] data, int offset, int size, int realFileIndex) {
 
   public FileData slice(final int offset, final int size) {
     this.checkBounds(offset, size);
-    return new FileData(this.data, this.offset + offset, size, -1);
+    return new FileData(this.data, this.offset + offset, size, this.virtualSize, -1);
   }
 
   public FileData slice(final int offset) {

--- a/src/main/java/legend/game/unpacker/MrgArchive.java
+++ b/src/main/java/legend/game/unpacker/MrgArchive.java
@@ -20,7 +20,7 @@ public class MrgArchive implements Iterable<MrgArchive.Entry> {
 
         for(int duplicateIndex = 0; duplicateIndex < i; duplicateIndex++) {
           if(this.entries[duplicateIndex] != null && this.entries[duplicateIndex].offset == offset) {
-            this.entries[i] = new Entry(offset, size, duplicateIndex);
+            this.entries[i] = new Entry(offset, size, size, duplicateIndex);
             continue outer;
           }
         }
@@ -46,7 +46,7 @@ public class MrgArchive implements Iterable<MrgArchive.Entry> {
 
         if(parentIndex != -1) {
           final Entry parent = this.getEntry(parentIndex);
-          this.entries[i] = new Entry(parent.offset, parent.size, parentIndex);
+          this.entries[i] = new Entry(parent.offset, parent.size, size, parentIndex);
         } else {
           this.entries[i] = new Entry(offset, size);
         }
@@ -89,9 +89,9 @@ public class MrgArchive implements Iterable<MrgArchive.Entry> {
     };
   }
 
-  public record Entry(int offset, int size, int parent) {
+  public record Entry(int offset, int size, int virtualSize, int parent) {
     public Entry(final int offset, final int size) {
-      this(offset, size, -1);
+      this(offset, size, size, -1);
     }
 
     public boolean virtual() {

--- a/src/main/java/legend/game/unpacker/Unpacker.java
+++ b/src/main/java/legend/game/unpacker/Unpacker.java
@@ -138,17 +138,21 @@ public final class Unpacker {
       if(Files.exists(mrg)) {
         try(final BufferedReader reader = Files.newBufferedReader(mrg)) {
           final Int2IntMap fileMap = new Int2IntArrayMap();
+          final ArrayList<Integer> fileSizes = new ArrayList<>();
 
           reader.lines().forEach(line -> {
-            final String[] parts = line.split("=");
+            final String[] parts = line.split("[=;]");
 
-            if(parts.length != 2) {
+            if(parts.length != 3) {
               throw new RuntimeException("Invalid MRG entry! " + line);
             }
 
             final int virtual = Integer.parseInt(parts[0]);
             final int real = Integer.parseInt(parts[1]);
             fileMap.put(virtual, real);
+            if(virtual != real) {
+              fileSizes.add(Integer.parseInt(parts[2]));
+            }
           });
 
           final List<FileData> files = new ArrayList<>();
@@ -188,7 +192,8 @@ public final class Unpacker {
 
             final Path file = dir.resolve(String.valueOf(real));
             if(Files.isRegularFile(file)) {
-              files.set(virtual, FileData.virtual(files.get(real), real));
+              final int virtualSize = fileSizes.remove(0);
+              files.set(virtual, FileData.virtual(files.get(real), virtualSize, real));
             }
           }
 
@@ -534,7 +539,7 @@ public final class Unpacker {
 
     i = 0;
     for(final MrgArchive.Entry entry : archive) {
-      sb.append(i).append('=').append(entry.virtual() ? entry.parent() : i).append('\n');
+      sb.append(i).append('=').append(entry.virtual() ? entry.parent() : i).append(';').append(entry.virtualSize()).append('\n');
       i++;
     }
 


### PR DESCRIPTION
It turns out that sometimes virtual files with sizes are referenced by indices hardcoded into scripts, and not having them present causes a softlock when the animation cannot be found (as with Lenus' water attacks and the floating animation). I double-checked the retail code in ghidra, and all the places we do `real()` checks, retail is just checking for `size != 0`, regardless of whether the file is a duplicate. To match that, I added a virtualSize to FileData that always holds the size found in the MRG table, and `real()` now checks that this isn't zero.

Fixes #558 