### PR TITLE
Uses texel's transparency bit when bit15=1 not forced

### DIFF
--- a/src/main/java/legend/core/gpu/Gpu.java
+++ b/src/main/java/legend/core/gpu/Gpu.java
@@ -1046,6 +1046,7 @@ public class Gpu {
     final int fr = texel        & 0xff;
     final int fg = texel >>>  8 & 0xff;
     final int fb = texel >>> 16 & 0xff;
+    final int tp = texel >>> 24 & 0x1;
     final int r;
     final int g;
     final int b;
@@ -1120,7 +1121,7 @@ public class Gpu {
       default -> throw new RuntimeException();
     }
 
-    return b << 16 | g << 8 | r;
+    return tp << 24 | b << 16 | g << 8 | r;
   }
 
   public int getShadedColor(final int w0, final int w1, final int w2, final int c0, final int c1, final int c2, final int area) {


### PR DESCRIPTION
Explanation is here: https://discord.com/channels/307164262063669248/318595603636551701/1112237383312748564

Relevant no$ documentation:
```
GP0(E6h) - Mask Bit Setting
  0     Set mask while drawing (0=TextureBit15, 1=ForceBit15=1)   ;GPUSTAT.11
  1     Check mask before draw (0=Draw Always, 1=Draw if Bit15=0) ;GPUSTAT.12
  2-23  Not used (zero)
  24-31 Command  (E6h)
When bit0 is off, the upper bit of the data written to the framebuffer is equal
to bit15 of the texture color (ie. it is set for colors that are marked as
"semi-transparent") (for untextured polygons, bit15 is set to zero).
```

Double check me, but I think this is the correct fix to use. I see no documentation for any instance where the transparency bit is forced to 0, so it should always be 1 (forced) or whatever is set in the texture color of the relevant CLUT.