### PR TITLE
Fixes potion ring/Detonating Arrow effects

### DIFF
--- a/src/main/java/legend/game/Scus94491BpeSegment_8004.java
+++ b/src/main/java/legend/game/Scus94491BpeSegment_8004.java
@@ -673,7 +673,7 @@ public final class Scus94491BpeSegment_8004 {
     scriptSubFunctions_8004e29c[760] = SEffe::FUN_80108df0;
     scriptSubFunctions_8004e29c[761] = Bttl_800d::allocateGuardEffect;
     scriptSubFunctions_8004e29c[762] = Bttl_800c::allocateWeaponTrailEffect;
-    scriptSubFunctions_8004e29c[763] = Bttl_800d::allocatePotionEffect;
+    scriptSubFunctions_8004e29c[763] = Bttl_800d::allocateRadialGradientEffect;
     scriptSubFunctions_8004e29c[764] = Bttl_800d::scriptAllocateAdditionScript;
     scriptSubFunctions_8004e29c[765] = Bttl_800c::FUN_800cfccc;
     scriptSubFunctions_8004e29c[766] = Bttl_800d::FUN_800d4338;

--- a/src/main/java/legend/game/combat/Bttl_800c.java
+++ b/src/main/java/legend/game/combat/Bttl_800c.java
@@ -40,7 +40,7 @@ import legend.game.combat.deff.DeffManager7cc;
 import legend.game.combat.effects.BttlScriptData6cSub13c;
 import legend.game.combat.effects.EffectManagerData6c;
 import legend.game.combat.effects.FullScreenOverlayEffect0e;
-import legend.game.combat.effects.PotionEffect14;
+import legend.game.combat.effects.RadialGradientEffect14;
 import legend.game.combat.effects.WeaponTrailEffect3c;
 import legend.game.combat.effects.WeaponTrailEffectSegment2c;
 import legend.game.combat.environment.BattleCamera;
@@ -466,14 +466,14 @@ public final class Bttl_800c {
   public static final MersenneTwisterSeed seed_800fa754 = MEMORY.ref(4, 0x800fa754L, MersenneTwisterSeed::new);
   /**
    * <ol start="0">
-   *   <li>{@link Bttl_800d#FUN_800d1d3c}</li>
+   *   <li>{@link Bttl_800d#renderDiscGradientEffect}</li>
    *   <li>{@link Bttl_800d#FUN_800d1e80}</li>
-   *   <li>{@link Bttl_800d#FUN_800d21b8}</li>
-   *   <li>{@link Bttl_800d#FUN_800d1d3c}</li>
-   *   <li>{@link Bttl_800d#FUN_800d21b8}</li>
+   *   <li>{@link Bttl_800d#renderRingGradientEffect}</li>
+   *   <li>{@link Bttl_800d#renderDiscGradientEffect}</li>
+   *   <li>{@link Bttl_800d#renderRingGradientEffect}</li>
    * </ol>
    */
-  public static final ArrayRef<Pointer<QuintConsumerRef<EffectManagerData6c, Integer, short[], PotionEffect14, Translucency>>> effectRenderers_800fa758 = MEMORY.ref(4, 0x800fa758L, ArrayRef.of(Pointer.classFor(QuintConsumerRef.classFor(EffectManagerData6c.class, int.class, short[].class, PotionEffect14.class, Translucency.class)), 5, 4, Pointer.deferred(4, QuintConsumerRef::new)));
+  public static final ArrayRef<Pointer<QuintConsumerRef<EffectManagerData6c, Integer, short[], RadialGradientEffect14, Translucency>>> radialGradientEffectRenderers_800fa758 = MEMORY.ref(4, 0x800fa758L, ArrayRef.of(Pointer.classFor(QuintConsumerRef.classFor(EffectManagerData6c.class, int.class, short[].class, RadialGradientEffect14.class, Translucency.class)), 5, 4, Pointer.deferred(4, QuintConsumerRef::new)));
 
   public static final Value _800fa76c = MEMORY.ref(4, 0x800fa76cL);
 

--- a/src/main/java/legend/game/combat/Bttl_800d.java
+++ b/src/main/java/legend/game/combat/Bttl_800d.java
@@ -643,8 +643,8 @@ public final class Bttl_800d {
       GPU.queueCommand(effect.z_04.get() + manager._10.z_22 >> 2, new GpuCommandPoly(3)
         .translucent(translucency)
         .rgb(0, manager._10.colour_1c.getX(), manager._10.colour_1c.getY(), manager._10.colour_1c.getZ())
-        .rgb(1, effect._0c.get(), effect._0d.get(), effect._0e.get())
-        .rgb(2, effect._0c.get(), effect._0d.get(), effect._0e.get())
+        .rgb(1, effect.r_0c.get(), effect.g_0d.get(), effect.b_0e.get())
+        .rgb(2, effect.r_0c.get(), effect.g_0d.get(), effect.b_0e.get())
         .pos(0, vertices[0], vertices[1])
         .pos(1, vertices[2], vertices[3])
         .pos(2, vertices[4], vertices[5])
@@ -659,8 +659,8 @@ public final class Bttl_800d {
   public static void renderRingGradientEffect(final EffectManagerData6c manager, final int angle, final short[] vertices, final RadialGradientEffect14 effect, final Translucency translucency) {
     if(manager._10.flags_00 >= 0) {
       final VECTOR sp0x20 = new VECTOR().set(
-        rcos(angle) * (manager._10.scale_16.getX() / effect._01.get() + manager._10._28) >> 12,
-        rsin(angle) * (manager._10.scale_16.getY() / effect._01.get() + manager._10._28) >> 12, // X is correct
+        rcos(angle) * (manager._10.scale_16.getX() / effect.scaleModifier_01.get() + manager._10._28) >> 12,
+        rsin(angle) * (manager._10.scale_16.getY() / effect.scaleModifier_01.get() + manager._10._28) >> 12, // X is correct
         manager._10._2c
       );
 
@@ -669,8 +669,8 @@ public final class Bttl_800d {
       FUN_800cfb14(manager, sp0x20, sp0x10, sp0x14);
 
       final VECTOR sp0x30 = new VECTOR().set(
-        rcos(angle + effect.angleStep_08.get()) * (manager._10.scale_16.getX() / effect._01.get() + manager._10._28) >> 12,
-        rsin(angle + effect.angleStep_08.get()) * (manager._10.scale_16.getY() / effect._01.get() + manager._10._28) >> 12,
+        rcos(angle + effect.angleStep_08.get()) * (manager._10.scale_16.getX() / effect.scaleModifier_01.get() + manager._10._28) >> 12,
+        rsin(angle + effect.angleStep_08.get()) * (manager._10.scale_16.getY() / effect.scaleModifier_01.get() + manager._10._28) >> 12,
         manager._10._2c
       );
 
@@ -682,8 +682,8 @@ public final class Bttl_800d {
         .translucent(translucency)
         .rgb(0, manager._10.colour_1c.getX(), manager._10.colour_1c.getY(), manager._10.colour_1c.getZ())
         .rgb(1, manager._10.colour_1c.getX(), manager._10.colour_1c.getY(), manager._10.colour_1c.getZ())
-        .rgb(2, effect._0c.get(), effect._0d.get(), effect._0e.get())
-        .rgb(3, effect._0c.get(), effect._0d.get(), effect._0e.get())
+        .rgb(2, effect.r_0c.get(), effect.g_0d.get(), effect.b_0e.get())
+        .rgb(3, effect.r_0c.get(), effect.g_0d.get(), effect.b_0e.get())
         .pos(0, sp0x10.get(), sp0x14.get())
         .pos(1, sp0x18.get(), sp0x1c.get())
         .pos(2, vertices[2], vertices[3])
@@ -697,7 +697,7 @@ public final class Bttl_800d {
   @Method(0x800d247cL)
   public static void renderRadialGradientEffect(final ScriptState<EffectManagerData6c> state, final EffectManagerData6c manager) {
     final RadialGradientEffect14 effect = (RadialGradientEffect14)manager.effect_44;
-    effect.angleStep_08.set(0x1000 / (0x4 << effect._00.get()));
+    effect.angleStep_08.set(0x1000 / (0x4 << effect.circleSubdivisionModifier_00.get()));
 
     final ShortRef sp0x48 = new ShortRef();
     final ShortRef sp0x4c = new ShortRef();
@@ -711,17 +711,17 @@ public final class Bttl_800d {
 
       //LAB_800d2510
       final VECTOR sp0x38 = new VECTOR().set(
-        rcos(0) * (manager._10.scale_16.getX() / effect._01.get()) >> 12,
-        rsin(0) * (manager._10.scale_16.getY() / effect._01.get()) >> 12,
+        rcos(0) * (manager._10.scale_16.getX() / effect.scaleModifier_01.get()) >> 12,
+        rsin(0) * (manager._10.scale_16.getY() / effect.scaleModifier_01.get()) >> 12,
         0
       );
 
       final ShortRef sp0x58 = new ShortRef();
       final ShortRef sp0x5c = new ShortRef();
       FUN_800cfb14(manager, sp0x38, sp0x58, sp0x5c);
-      effect._0c.set(manager._10._24 >>> 16 & 0xff);
-      effect._0d.set(manager._10._24 >>>  8 & 0xff);
-      effect._0e.set(manager._10._24        & 0xff);
+      effect.r_0c.set(manager._10._24 >>> 16 & 0xff);
+      effect.g_0d.set(manager._10._24 >>>  8 & 0xff);
+      effect.b_0e.set(manager._10._24        & 0xff);
 
       //LAB_800d25b4
       for(int angle = 0; angle < 0x1000; ) {
@@ -729,8 +729,8 @@ public final class Bttl_800d {
         final ShortRef sp0x54 = new ShortRef().set(sp0x5c.get());
 
         sp0x38.set(
-          rcos(angle + effect.angleStep_08.get()) * (manager._10.scale_16.getX() / effect._01.get()) >> 12,
-          rsin(angle + effect.angleStep_08.get()) * (manager._10.scale_16.getY() / effect._01.get()) >> 12,
+          rcos(angle + effect.angleStep_08.get()) * (manager._10.scale_16.getX() / effect.scaleModifier_01.get()) >> 12,
+          rsin(angle + effect.angleStep_08.get()) * (manager._10.scale_16.getY() / effect.scaleModifier_01.get()) >> 12,
           0
         );
 
@@ -764,8 +764,8 @@ public final class Bttl_800d {
     manager._10.scale_16.set((short)0x1000, (short)0x1000, (short)0x1000);
 
     final RadialGradientEffect14 effect = (RadialGradientEffect14)manager.effect_44;
-    effect._00.set(s2);
-    effect._01.set((s1 - 3 & 0xffff_ffffL) >= 2 ? 4 : 1);
+    effect.circleSubdivisionModifier_00.set(s2);
+    effect.scaleModifier_01.set((s1 - 3 & 0xffff_ffffL) >= 2 ? 4 : 1);
     effect.renderer_10.set(radialGradientEffectRenderers_800fa758.get(s1).deref());
     script.params_20[0].set(state.index);
     return FlowControl.CONTINUE;

--- a/src/main/java/legend/game/combat/Bttl_800d.java
+++ b/src/main/java/legend/game/combat/Bttl_800d.java
@@ -32,7 +32,7 @@ import legend.game.combat.effects.EffectManagerData6c;
 import legend.game.combat.effects.EffectManagerData6cInner;
 import legend.game.combat.effects.GuardEffect06;
 import legend.game.combat.effects.MonsterDeathEffect34;
-import legend.game.combat.effects.PotionEffect14;
+import legend.game.combat.effects.RadialGradientEffect14;
 import legend.game.combat.effects.ProjectileHitEffect14;
 import legend.game.combat.effects.ProjectileHitEffect14Sub48;
 import legend.game.combat.environment.BattleCamera;
@@ -153,7 +153,7 @@ import static legend.game.combat.Bttl_800c.camera_800c67f0;
 import static legend.game.combat.Bttl_800c.charWidthAdjustTable_800fa7cc;
 import static legend.game.combat.Bttl_800c.currentAddition_800c6790;
 import static legend.game.combat.Bttl_800c.deffManager_800c693c;
-import static legend.game.combat.Bttl_800c.effectRenderers_800fa758;
+import static legend.game.combat.Bttl_800c.radialGradientEffectRenderers_800fa758;
 import static legend.game.combat.Bttl_800c.screenOffsetX_800c67bc;
 import static legend.game.combat.Bttl_800c.screenOffsetY_800c67c0;
 import static legend.game.combat.Bttl_800c.scriptGetScriptedObjectPos;
@@ -636,8 +636,9 @@ public final class Bttl_800d {
     return FlowControl.CONTINUE;
   }
 
+  /** Renders things like the two-tone disc at the start of Detonating Arrow */
   @Method(0x800d1d3cL)
-  public static void FUN_800d1d3c(final EffectManagerData6c manager, final int angle, final short[] vertices, final PotionEffect14 effect, final Translucency translucency) {
+  public static void renderDiscGradientEffect(final EffectManagerData6c manager, final int angle, final short[] vertices, final RadialGradientEffect14 effect, final Translucency translucency) {
     if(manager._10.flags_00 >= 0) {
       GPU.queueCommand(effect.z_04.get() + manager._10.z_22 >> 2, new GpuCommandPoly(3)
         .translucent(translucency)
@@ -653,8 +654,9 @@ public final class Bttl_800d {
     //LAB_800d1e70
   }
 
+  /** Renders things like the ring effect when using a healing potion */
   @Method(0x800d21b8L)
-  public static void FUN_800d21b8(final EffectManagerData6c manager, final int angle, final short[] vertices, final PotionEffect14 effect, final Translucency translucency) {
+  public static void renderRingGradientEffect(final EffectManagerData6c manager, final int angle, final short[] vertices, final RadialGradientEffect14 effect, final Translucency translucency) {
     if(manager._10.flags_00 >= 0) {
       final VECTOR sp0x20 = new VECTOR().set(
         rcos(angle) * (manager._10.scale_16.getX() / effect._01.get() + manager._10._28) >> 12,
@@ -693,8 +695,8 @@ public final class Bttl_800d {
   }
 
   @Method(0x800d247cL)
-  public static void renderPotionEffect(final ScriptState<EffectManagerData6c> state, final EffectManagerData6c manager) {
-    final PotionEffect14 effect = (PotionEffect14)manager.effect_44;
+  public static void renderRadialGradientEffect(final ScriptState<EffectManagerData6c> state, final EffectManagerData6c manager) {
+    final RadialGradientEffect14 effect = (RadialGradientEffect14)manager.effect_44;
     effect.angleStep_08.set(0x1000 / (0x4 << effect._00.get()));
 
     final ShortRef sp0x48 = new ShortRef();
@@ -742,18 +744,18 @@ public final class Bttl_800d {
   }
 
   @Method(0x800d2734L)
-  public static FlowControl allocatePotionEffect(final RunningScript<? extends BattleScriptDataBase> script) {
+  public static FlowControl allocateRadialGradientEffect(final RunningScript<? extends BattleScriptDataBase> script) {
     final int s2 = script.params_20[1].get();
     final int s1 = script.params_20[2].get();
 
     final ScriptState<EffectManagerData6c> state = allocateEffectManager(
-      "PotionEffect14",
+      "RadialGradientEffect14",
       script.scriptState_04,
       0x14,
       null,
-      Bttl_800d::renderPotionEffect,
+      Bttl_800d::renderRadialGradientEffect,
       null,
-      PotionEffect14::new
+      RadialGradientEffect14::new
     );
 
     final EffectManagerData6c manager = state.innerStruct_00;
@@ -761,10 +763,10 @@ public final class Bttl_800d {
     //LAB_800d27b4
     manager._10.scale_16.set((short)0x1000, (short)0x1000, (short)0x1000);
 
-    final PotionEffect14 effect = (PotionEffect14)manager.effect_44;
+    final RadialGradientEffect14 effect = (RadialGradientEffect14)manager.effect_44;
     effect._00.set(s2);
-    effect._01.set(s1 - 3 > 1 ? 4 : 1);
-    effect.renderer_10.set(effectRenderers_800fa758.get(s1).deref());
+    effect._01.set((s1 - 3 & 0xffff_ffffL) >= 2 ? 4 : 1);
+    effect.renderer_10.set(radialGradientEffectRenderers_800fa758.get(s1).deref());
     script.params_20[0].set(state.index);
     return FlowControl.CONTINUE;
   }

--- a/src/main/java/legend/game/combat/effects/RadialGradientEffect14.java
+++ b/src/main/java/legend/game/combat/effects/RadialGradientEffect14.java
@@ -8,7 +8,7 @@ import legend.core.memory.types.QuintConsumerRef;
 import legend.core.memory.types.UnsignedByteRef;
 import legend.game.types.Translucency;
 
-public class PotionEffect14 implements BttlScriptData6cSubBase1, MemoryRef {
+public class RadialGradientEffect14 implements BttlScriptData6cSubBase1, MemoryRef {
   private final Value ref;
 
   public final UnsignedByteRef _00;
@@ -20,9 +20,9 @@ public class PotionEffect14 implements BttlScriptData6cSubBase1, MemoryRef {
   public final UnsignedByteRef _0d;
   public final UnsignedByteRef _0e;
 
-  public final Pointer<QuintConsumerRef<EffectManagerData6c, Integer, short[], PotionEffect14, Translucency>> renderer_10;
+  public final Pointer<QuintConsumerRef<EffectManagerData6c, Integer, short[], RadialGradientEffect14, Translucency>> renderer_10;
 
-  public PotionEffect14(final Value ref) {
+  public RadialGradientEffect14(final Value ref) {
     this.ref = ref;
 
     this._00 = ref.offset(1, 0x00L).cast(UnsignedByteRef::new);

--- a/src/main/java/legend/game/combat/effects/RadialGradientEffect14.java
+++ b/src/main/java/legend/game/combat/effects/RadialGradientEffect14.java
@@ -11,28 +11,28 @@ import legend.game.types.Translucency;
 public class RadialGradientEffect14 implements BttlScriptData6cSubBase1, MemoryRef {
   private final Value ref;
 
-  public final UnsignedByteRef _00;
-  public final UnsignedByteRef _01;
+  public final UnsignedByteRef circleSubdivisionModifier_00;
+  public final UnsignedByteRef scaleModifier_01;
 
   public final IntRef z_04;
   public final IntRef angleStep_08;
-  public final UnsignedByteRef _0c;
-  public final UnsignedByteRef _0d;
-  public final UnsignedByteRef _0e;
+  public final UnsignedByteRef r_0c;
+  public final UnsignedByteRef g_0d;
+  public final UnsignedByteRef b_0e;
 
   public final Pointer<QuintConsumerRef<EffectManagerData6c, Integer, short[], RadialGradientEffect14, Translucency>> renderer_10;
 
   public RadialGradientEffect14(final Value ref) {
     this.ref = ref;
 
-    this._00 = ref.offset(1, 0x00L).cast(UnsignedByteRef::new);
-    this._01 = ref.offset(1, 0x01L).cast(UnsignedByteRef::new);
+    this.circleSubdivisionModifier_00 = ref.offset(1, 0x00L).cast(UnsignedByteRef::new);
+    this.scaleModifier_01 = ref.offset(1, 0x01L).cast(UnsignedByteRef::new);
 
     this.z_04 = ref.offset(4, 0x04L).cast(IntRef::new);
     this.angleStep_08 = ref.offset(4, 0x08L).cast(IntRef::new);
-    this._0c = ref.offset(1, 0x0cL).cast(UnsignedByteRef::new);
-    this._0d = ref.offset(1, 0x0dL).cast(UnsignedByteRef::new);
-    this._0e = ref.offset(1, 0x0eL).cast(UnsignedByteRef::new);
+    this.r_0c = ref.offset(1, 0x0cL).cast(UnsignedByteRef::new);
+    this.g_0d = ref.offset(1, 0x0dL).cast(UnsignedByteRef::new);
+    this.b_0e = ref.offset(1, 0x0eL).cast(UnsignedByteRef::new);
 
     this.renderer_10 = ref.offset(4, 0x10L).cast(Pointer.deferred(4, QuintConsumerRef::new));
   }


### PR DESCRIPTION
`effect._01` is supposed to be set using an unsigned comparison, not signed (L768).