### PR TITLE
Fixes wounded Virage claw attack dust

### DIFF
--- a/src/main/java/legend/game/combat/SEffe.java
+++ b/src/main/java/legend/game/combat/SEffe.java
@@ -2147,8 +2147,7 @@ public final class SEffe {
       scriptGetScriptedObjectPos(a2.scriptIndex_04, sp0x30);
 
       final VECTOR sp0x10 = new VECTOR().set(sp0x20).sub(sp0x30);
-      a3._50.set(sp0x10);
-      a3._50.set(sp0x10);
+      a3._50.sub(sp0x10);
     }
 
     //LAB_80100e14


### PR DESCRIPTION
Particle position was being set to a position difference vector twice instead of having the difference vector subtracted from it.