### PR TITLE
Change how DEFF files are referenced when package is loaded

### DIFF
--- a/src/main/java/legend/game/combat/Bttl_800e.java
+++ b/src/main/java/legend/game/combat/Bttl_800e.java
@@ -83,6 +83,7 @@ import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.BiConsumer;
@@ -1319,8 +1320,22 @@ public final class Bttl_800e {
   public static void loadDeffPackage(final List<FileData> files, final ScriptState<EffectManagerData6c> state) {
     LOGGER.info(DEFF, "Loading DEFF files");
 
-    deffManager_800c693c.deffPackage_5a8 = files;
-    prepareDeffFiles(files, state);
+    deffManager_800c693c.deffPackage_5a8 = new ArrayList<>();
+    for(int i = 0; i < files.size(); i++) {
+      final FileData data = files.get(i);
+      final int flags = data.readInt(0);
+      final DeffPart deffPart = switch(flags >>> 24) {
+        case 0 -> new DeffPart.LmbType(data);
+        case 1, 2 -> new DeffPart.AnimatedTmdType("DEFF index %d (flags %08x)".formatted(i, flags), data);
+        case 3 -> new DeffPart.TmdType("DEFF index %d (flags %08x)".formatted(i, flags), data);
+        case 4 -> new DeffPart.SpriteType(data);
+        // Example: d-attack (DRGN0.4236.0.0)
+        case 5 -> new DeffPart.AnimatedTmdType("DEFF index %d (flags %08x)".formatted(i, flags), data);
+        default -> throw new IllegalArgumentException("Invalid DEFF type %x".formatted(flags & 0xff00_0000));
+      };
+      deffManager_800c693c.deffPackage_5a8.add(deffPart);
+      prepareDeffFiles(files, state);
+    }
   }
 
   @Method(0x800e70bcL)
@@ -2647,24 +2662,13 @@ public final class Bttl_800e {
   /** See {@link DeffPart#flags_00} */
   @Method(0x800eac58L)
   public static DeffPart getDeffPart(final int flags) {
-    final List<FileData> deff = deffManager_800c693c.deffPackage_5a8;
+    final List<DeffPart> deff = deffManager_800c693c.deffPackage_5a8;
 
     //LAB_800eac84
-    for(int i = 0; i < deff.size(); i++) {
-      final FileData data = deff.get(i);
-
-      if(data.readInt(0) == flags) {
-        return switch(flags >>> 24) {
-          case 0 -> new DeffPart.LmbType(data);
-          case 1, 2 -> new DeffPart.AnimatedTmdType("DEFF index %d (flags %08x)".formatted(i, flags), data);
-          case 3 -> new DeffPart.TmdType("DEFF index %d (flags %08x)".formatted(i, flags), data);
-          case 4 -> new DeffPart.SpriteType(data);
-          // Example: d-attack (DRGN0.4236.0.0)
-          case 5 -> new DeffPart.AnimatedTmdType("DEFF index %d (flags %08x)".formatted(i, flags), data);
-          default -> throw new IllegalArgumentException("Invalid DEFF type %x".formatted(flags & 0xff00_0000));
-        };
+    for(final DeffPart deffPart : deff) {
+      if(deffPart.flags_00 == flags) {
+        return deffPart;
       }
-
       //LAB_800eaca0
     }
 

--- a/src/main/java/legend/game/combat/Bttl_800e.java
+++ b/src/main/java/legend/game/combat/Bttl_800e.java
@@ -83,7 +83,6 @@ import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.BiConsumer;
@@ -1320,22 +1319,9 @@ public final class Bttl_800e {
   public static void loadDeffPackage(final List<FileData> files, final ScriptState<EffectManagerData6c> state) {
     LOGGER.info(DEFF, "Loading DEFF files");
 
-    deffManager_800c693c.deffPackage_5a8 = new ArrayList<>();
-    for(int i = 0; i < files.size(); i++) {
-      final FileData data = files.get(i);
-      final int flags = data.readInt(0);
-      final DeffPart deffPart = switch(flags >>> 24) {
-        case 0 -> new DeffPart.LmbType(data);
-        case 1, 2 -> new DeffPart.AnimatedTmdType("DEFF index %d (flags %08x)".formatted(i, flags), data);
-        case 3 -> new DeffPart.TmdType("DEFF index %d (flags %08x)".formatted(i, flags), data);
-        case 4 -> new DeffPart.SpriteType(data);
-        // Example: d-attack (DRGN0.4236.0.0)
-        case 5 -> new DeffPart.AnimatedTmdType("DEFF index %d (flags %08x)".formatted(i, flags), data);
-        default -> throw new IllegalArgumentException("Invalid DEFF type %x".formatted(flags & 0xff00_0000));
-      };
-      deffManager_800c693c.deffPackage_5a8.add(deffPart);
-      prepareDeffFiles(files, state);
-    }
+    deffManager_800c693c.deffPackage_5a8 = new DeffPart[files.size()];
+    Arrays.setAll(deffManager_800c693c.deffPackage_5a8, i -> DeffPart.getDeffPart(files, i));
+    prepareDeffFiles(files, state);
   }
 
   @Method(0x800e70bcL)
@@ -2662,10 +2648,8 @@ public final class Bttl_800e {
   /** See {@link DeffPart#flags_00} */
   @Method(0x800eac58L)
   public static DeffPart getDeffPart(final int flags) {
-    final List<DeffPart> deff = deffManager_800c693c.deffPackage_5a8;
-
     //LAB_800eac84
-    for(final DeffPart deffPart : deff) {
+    for(final DeffPart deffPart : deffManager_800c693c.deffPackage_5a8) {
       if(deffPart.flags_00 == flags) {
         return deffPart;
       }

--- a/src/main/java/legend/game/combat/SEffe.java
+++ b/src/main/java/legend/game/combat/SEffe.java
@@ -4887,7 +4887,7 @@ public final class SEffe {
     //LAB_80109ce0
   }
 
-  /** Kubila demon frog, Lloyd's cape, ??? */
+  /** Kubila demon frog, Lloyd's cape, Selebus' strapple and zambo hands, Grand Jewel heal, etc. */
   @Method(0x80109d30L)
   public static FlowControl allocateVertexDifferenceAnimation(final RunningScript<?> script) {
     final int ticksRemaining = script.params_20[2].get();

--- a/src/main/java/legend/game/combat/deff/DeffManager7cc.java
+++ b/src/main/java/legend/game/combat/deff/DeffManager7cc.java
@@ -1,14 +1,13 @@
 package legend.game.combat.deff;
 
 import legend.core.gte.TmdObjTable1c;
+import legend.game.combat.effects.EffectManagerData6c;
 import legend.game.combat.environment.BattleLightStruct64;
 import legend.game.combat.environment.BttlLightStruct84;
-import legend.game.combat.effects.EffectManagerData6c;
-import legend.game.combat.types.SpriteMetrics08;
 import legend.game.combat.environment.StageAmbiance4c;
+import legend.game.combat.types.SpriteMetrics08;
 import legend.game.scripting.ScriptFile;
 import legend.game.scripting.ScriptState;
-import legend.game.unpacker.FileData;
 
 import java.util.Arrays;
 import java.util.List;
@@ -41,7 +40,7 @@ public class DeffManager7cc {
   public final TmdObjTable1c[] tmds_2f8 = new TmdObjTable1c[38];
   public final DeffPart.LmbType[] lmbs_390 = new DeffPart.LmbType[3];
   public final SpriteMetrics08[] spriteMetrics_39c = new SpriteMetrics08[65];
-  public List<FileData> deffPackage_5a8;
+  public List<DeffPart> deffPackage_5a8;
 //  public DeffFile deff_5ac; // No longer needed
 
   public final BattleStruct24_2 _5b8 = new BattleStruct24_2();

--- a/src/main/java/legend/game/combat/deff/DeffManager7cc.java
+++ b/src/main/java/legend/game/combat/deff/DeffManager7cc.java
@@ -10,7 +10,6 @@ import legend.game.scripting.ScriptFile;
 import legend.game.scripting.ScriptState;
 
 import java.util.Arrays;
-import java.util.List;
 
 public class DeffManager7cc {
   public Struct08 _00 = new Struct08();
@@ -40,7 +39,7 @@ public class DeffManager7cc {
   public final TmdObjTable1c[] tmds_2f8 = new TmdObjTable1c[38];
   public final DeffPart.LmbType[] lmbs_390 = new DeffPart.LmbType[3];
   public final SpriteMetrics08[] spriteMetrics_39c = new SpriteMetrics08[65];
-  public List<DeffPart> deffPackage_5a8;
+  public DeffPart[] deffPackage_5a8;
 //  public DeffFile deff_5ac; // No longer needed
 
   public final BattleStruct24_2 _5b8 = new BattleStruct24_2();

--- a/src/main/java/legend/game/combat/deff/DeffPart.java
+++ b/src/main/java/legend/game/combat/deff/DeffPart.java
@@ -5,6 +5,8 @@ import legend.game.types.CContainer;
 import legend.game.types.TmdAnimationFile;
 import legend.game.unpacker.FileData;
 
+import java.util.List;
+
 public class DeffPart {
   /**
    * MSB is type, LSB is index, middle bytes are some kind of ID?
@@ -22,6 +24,20 @@ public class DeffPart {
 
   public DeffPart(final FileData data) {
     this.flags_00 = data.readInt(0);
+  }
+
+  public static DeffPart getDeffPart(final List<FileData> files, final int i) {
+    final FileData data = files.get(i);
+    final int flags = data.readInt(0);
+    return switch(flags >>> 24) {
+      case 0 -> new DeffPart.LmbType(data);
+      case 1, 2 -> new DeffPart.AnimatedTmdType("DEFF index %d (flags %08x)".formatted(i, flags), data);
+      case 3 -> new DeffPart.TmdType("DEFF index %d (flags %08x)".formatted(i, flags), data);
+      case 4 -> new DeffPart.SpriteType(data);
+      // Example: d-attack (DRGN0.4236.0.0)
+      case 5 -> new DeffPart.AnimatedTmdType("DEFF index %d (flags %08x)".formatted(i, flags), data);
+      default -> throw new IllegalArgumentException("Invalid DEFF type %x".formatted(flags & 0xff00_0000));
+    };
   }
 
   public static class LmbType extends DeffPart {


### PR DESCRIPTION
Some vertex difference animations use multiple copies of the same file within a DEFF. In retail, all of the deff parts are copied into memory, and all TMDs (and other types) are set as references to these parts, rather than new copies. That means that if multiple scripts reference the same part, any changes made to the TMD in one script are also reflected in the other scripts. Therefore, any vertex difference calculations can be performed once on a single script, and the change will be reflected across all scripts referencing that part, each of which can have its own translation, rotation, etc.

The issue in SC was that every time a new DEFF TMD was allocated, getDeffParts would return a new copy of the TMD data to attach to the script state. Thus, transformations performed on a script *only* affected the copy of the TMD attached to that script, instead of affecting all scripts referencing that TMD.

This PR alters how DEFF packages are loaded so that deffPackages_5a8 contains an array of DeffPart instances instead of just the file data, so that allocated DEFF TMDs can correctly contain shared references to this data, as in retail.