### PR TITLE
Fix messageBox fade out spam

### DIFF
--- a/src/main/java/legend/game/inventory/screens/MessageBoxScreen.java
+++ b/src/main/java/legend/game/inventory/screens/MessageBoxScreen.java
@@ -160,7 +160,7 @@ public class MessageBoxScreen extends MenuScreen {
   }
 
   private boolean skipInput() {
-    if(this.messageBox.state_0c == 5) {
+    if(this.messageBox.state_0c == 5 || this.messageBox.state_0c == 4) {
       return true;
     }
 

--- a/src/main/java/legend/game/inventory/screens/MessageBoxScreen.java
+++ b/src/main/java/legend/game/inventory/screens/MessageBoxScreen.java
@@ -160,6 +160,10 @@ public class MessageBoxScreen extends MenuScreen {
   }
 
   private boolean skipInput() {
+    if(this.messageBox.state_0c == 5) {
+      return true;
+    }
+
     if(this.messageBox.type_15 == 0) {
       playSound(2);
       this.result = MessageBoxResult.YES;


### PR DESCRIPTION
## Description
• state_0c ==5 and state=_0c == 4 seem to only be used during message box fade out animations
• Since this is the intent of the two states, it seems appropriate to use them
• skipInput is the logical choice to place this check
• This avoids the messageBox from detecting and reacting to any input during the animation

## Extenuating Concerns
• If someone has used state 5 or state 4 for something weird...that should be fixed when found
• This will help prevent people using the awkward message box handlers and overrides incorrectly by doing them a favour and locking them out of state 5 and state 4 input concerns lol ✔
• The initial animation of the message box growing in size is not cancelled and the fullsize message box animation is where it begins, so it looks slightly choppy if you know to watch for it

## Testing
• Tested all the menus I could think of to ensure this does not lock up input beyond just the message box
• Any ideas of what other uncommon menus or message box uses to test?

## Future
• A proper kill signal to the message box on the stack would be more appropriate but this refactor would be nuts for the current menu system. I believe the menuStack.popScreen would need to be expanded for this with proper handling of side-effects like animations.

• We can call menuStack.popScreen() in the type_15 check. However, this doesn't respect animations, leaves the door open for null checks to be needed in the rest of the flow, and doesn't close all boxes as needed throughout the menus. Ex: In use item, use an item and before the animation ends, hit Circle. These types of edge cases pop up everywhere with this means.

Closes #582