### PR TITLE
Fix mouse clicks destroying conroller/kb controls on main menu

### DIFF
--- a/src/main/java/legend/game/inventory/screens/MainMenuScreen.java
+++ b/src/main/java/legend/game/inventory/screens/MainMenuScreen.java
@@ -154,7 +154,7 @@ public class MainMenuScreen extends MenuScreen {
   @Override
   public void setFocus(@Nullable final Control control) {
     // Don't allow complete unfocusing
-    if(control != null) {
+    if(control instanceof Button) {
       super.setFocus(control);
     }
   }


### PR DESCRIPTION
Currently if you click character portraits, or anything but the main menu buttons you will lose focus to a non-button control. Then the current code doesn't know how to process the index in the button delegates for controller/kb inputs.

This change checks to make sure the main menu focus is retained to the main menu buttons only, even if the mouse clicks outside of it.

Not sure if this is the best place to make this change but it doesn't impact the other screens so it seems unique to mainmenuscreen.java.