### PR TITLE
Fixes crash when using weapons that apply poison

### DIFF
--- a/src/main/java/legend/game/combat/Bttl_800f.java
+++ b/src/main/java/legend/game/combat/Bttl_800f.java
@@ -35,6 +35,7 @@ import legend.game.scripting.RunningScript;
 import legend.game.scripting.ScriptState;
 import legend.game.types.ActiveStatsa0;
 import legend.game.types.LodString;
+import legend.game.types.SpellStats0c;
 import legend.game.types.Translucency;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -2758,7 +2759,7 @@ public final class Bttl_800f {
         LOGGER.error("Retail bug: spell index out of bounds (%d). This is known to happen during Shana/Miranda's dragoon attack.", bobj.spellId_4e);
       }
 
-      bobj.spell_94 = null;
+      bobj.spell_94 = new SpellStats0c();
     }
 
     //LAB_800f7c54

--- a/src/main/java/legend/game/types/SpellStats0c.java
+++ b/src/main/java/legend/game/types/SpellStats0c.java
@@ -1,7 +1,7 @@
 package legend.game.types;
 
 import legend.game.characters.Element;
-import legend.game.modding.coremod.elements.NoElement;
+import legend.game.modding.coremod.CoreMod;
 import legend.game.unpacker.FileData;
 
 public class SpellStats0c {
@@ -59,7 +59,7 @@ public class SpellStats0c {
     this.accuracy_05 = 0;
     this.mp_06 = 0;
     this.statusChance_07 = 0;
-    this.element_08 = new NoElement();
+    this.element_08 = CoreMod.NO_ELEMENT.get();
     this.statusType_09 = 0;
     this.buffType_0a = 0;
     this._0b = 0;

--- a/src/main/java/legend/game/types/SpellStats0c.java
+++ b/src/main/java/legend/game/types/SpellStats0c.java
@@ -1,6 +1,7 @@
 package legend.game.types;
 
 import legend.game.characters.Element;
+import legend.game.modding.coremod.elements.NoElement;
 import legend.game.unpacker.FileData;
 
 public class SpellStats0c {
@@ -58,7 +59,7 @@ public class SpellStats0c {
     this.accuracy_05 = 0;
     this.mp_06 = 0;
     this.statusChance_07 = 0;
-    this.element_08 = Element.fromFlag(0);
+    this.element_08 = new NoElement();
     this.statusType_09 = 0;
     this.buffType_0a = 0;
     this._0b = 0;

--- a/src/main/java/legend/game/types/SpellStats0c.java
+++ b/src/main/java/legend/game/types/SpellStats0c.java
@@ -47,6 +47,23 @@ public class SpellStats0c {
     return new SpellStats0c(name, combatDescription, targetType_00, flags_01, specialEffect_02, damage_03, multi_04, accuracy_05, mp_06, statusChance_07, element_08, statusType_09, buffType_0a, _0b);
   }
 
+  public SpellStats0c() {
+    this.name = "";
+    this.combatDescription = "";
+    this.targetType_00 = 0;
+    this.flags_01 = 0;
+    this.specialEffect_02 = 0;
+    this.damageMultiplier_03 = 0;
+    this.multi_04 = 0;
+    this.accuracy_05 = 0;
+    this.mp_06 = 0;
+    this.statusChance_07 = 0;
+    this.element_08 = Element.fromFlag(0);
+    this.statusType_09 = 0;
+    this.buffType_0a = 0;
+    this._0b = 0;
+  }
+  
   public SpellStats0c(final String name, final String combatDescription, final int targetType, final int flags, final int specialEffect, final int damage, final int multi, final int accuracy, final int mp, final int statusChance, final Element element, final int statusType, final int buffType, final int _0b) {
     this.name = name;
     this.combatDescription = combatDescription;


### PR DESCRIPTION
Prior to stats changes, the fields grouped into SpellStats0c were set to 0 when spellID was >127. This got changed to setting bobj.spell_94 to null, which throws an error when the checkHit method tries to access one of the values. Thought about adding a null check, but thought replicating the prior behavior with a default constructor would be safer.