### PR TITLE
Fix Dart moonwalking

### DIFF
--- a/src/main/java/legend/game/submap/SMap.java
+++ b/src/main/java/legend/game/submap/SMap.java
@@ -2309,7 +2309,7 @@ public class SMap extends EngineState {
     final float deltaX = script.params_20[1].get() - model.coord2_14.coord.transfer.x;
     final float deltaZ = script.params_20[3].get() - model.coord2_14.coord.transfer.z;
 
-    if(deltaX != 0.0f && deltaZ != 0.0f) {
+    if(deltaX != 0.0f || deltaZ != 0.0f) {
       model.coord2_14.transforms.rotate.y = MathHelper.positiveAtan2(deltaZ, deltaX);
     }
 


### PR DESCRIPTION
When Dart is facing exactly in a cardinal direction, moving exactly the opposite direction would leave one of the deltas at 0, which would skip the y rotation recalculation. Originally there was no check for this. I changed it so as long as one delta is non-zero, it would recalculate the y rotation, so it will still do nothing in the case where both deltas are zero.

Fixes #748 (commit 89a55bd5 was where the bug was introduced)