### PR TITLE
Fixed another wmap smoke bug

### DIFF
--- a/src/main/java/legend/game/wmap/WMap.java
+++ b/src/main/java/legend/game/wmap/WMap.java
@@ -175,7 +175,7 @@ public class WMap extends EngineState {
 
   private int destinationLabelStage_800c86f0;
 
-  private WmapSmokeCloudInstance60[] smokeCloudInstances_800c86f8;
+  private WmapSmokeInstance60[] smokeInstances_800c86f8;
   /** This doesn't seem to have any effect, since the only time it's used is checking whether to turn it off */
   private boolean renderAtmosphericEffect_800c86fc;
   private final RECT storedEffectsRect_800c8700 = new RECT((short)576, (short)256, (short)128, (short)256);
@@ -6588,14 +6588,14 @@ public class WMap extends EngineState {
     this.currentWmapEffect_800f6598 = (locations_800f0e34.get(this.mapState_800c6798.locationIndex_10).effectFlags_12.get() & 0x30) >>> 4;
     this.previousWmapEffect_800f659c = this.currentWmapEffect_800f6598;
 
-    this.smokeCloudInstances_800c86f8 = new WmapSmokeCloudInstance60[48];
+    this.smokeInstances_800c86f8 = new WmapSmokeInstance60[48];
     this.renderAtmosphericEffect_800c86fc = false;
 
-    Arrays.setAll(this.smokeCloudInstances_800c86f8, i -> new WmapSmokeCloudInstance60());
+    Arrays.setAll(this.smokeInstances_800c86f8, i -> new WmapSmokeInstance60());
 
     //LAB_800eb9b8
     for(int i = 0; i < 48; i++) {
-      final WmapSmokeCloudInstance60 smoke = this.smokeCloudInstances_800c86f8[i];
+      final WmapSmokeInstance60 smoke = this.smokeInstances_800c86f8[i];
 
       //LAB_800eb9d4
       GsInitCoordinate2(null, smoke.coord2_00);
@@ -7064,10 +7064,10 @@ public class WMap extends EngineState {
     }
 
     //LAB_800edc84
+    int smokeIndex = 0;
+
     //LAB_800edca8
     for(int i = 0; i < this.placeCount_800c86cc; i++) {
-      final WmapSmokeCloudInstance60 smoke = this.smokeCloudInstances_800c86f8[i];
-
       //LAB_800edccc
       if(!places_800f0234.get(locations_800f0e34.get(locationsIndices_800c84c8.get(i).get()).placeIndex_02.get()).name_00.isNull()) {
         //LAB_800edd3c
@@ -7085,6 +7085,8 @@ public class WMap extends EngineState {
             //LAB_800ede1c
             for(int j = 0; j < 6; j++) {
               //LAB_800ede38
+              final WmapSmokeInstance60 smoke = this.smokeInstances_800c86f8[smokeIndex];
+
               final float size;
               if(mode == 8) {
                 size = smoke.scaleAndColourFade_50 / 5.0f;
@@ -7216,6 +7218,7 @@ public class WMap extends EngineState {
                                   smoke.scaleAndColourFade_50 = 0;
                                 }
                                 //LAB_800eeccc
+                                smokeIndex++;
                               }
                             }
                           }
@@ -7250,7 +7253,7 @@ public class WMap extends EngineState {
 
   @Method(0x800eede4L)
   private void deallocateSmoke() {
-    this.smokeCloudInstances_800c86f8 = null;
+    this.smokeInstances_800c86f8 = null;
     this.atmosphericEffectDeallocators_800f65bc[this.currentWmapEffect_800f6598].run();
   }
 }

--- a/src/main/java/legend/game/wmap/WmapSmokeInstance60.java
+++ b/src/main/java/legend/game/wmap/WmapSmokeInstance60.java
@@ -3,7 +3,7 @@ package legend.game.wmap;
 import legend.core.gte.GsCOORDINATE2;
 import org.joml.Vector3f;
 
-public class WmapSmokeCloudInstance60 {
+public class WmapSmokeInstance60 {
   public final GsCOORDINATE2 coord2_00 = new GsCOORDINATE2();
   public float scaleAndColourFade_50;
   public final Vector3f translationOffset_54 = new Vector3f();


### PR DESCRIPTION
The smoke clouds are behaving correctly now. I *think* the changes are placed correctly according to the asm. The initial struct pointer is set just before the first loop, and the pointer is advanced to the next struct in the array right after the GPU packet is queued inside the inner loop. It seems to be done this way because any single location only has 6 smoke cloud instances, but you can have multiple locations with smoke clouds in a continent at the same time, which is why the pointer increments separately from both the inner and outer loops.