### PR TITLE
Implemented WMAP snow

### DIFF
--- a/src/main/java/legend/game/wmap/WMap.java
+++ b/src/main/java/legend/game/wmap/WMap.java
@@ -6009,7 +6009,7 @@ public class WMap extends EngineState {
                   //LAB_800ec83c
                   //LAB_800ec870
                   //LAB_800ec8a4
-                  cloud.queueZ = i < 12 ? 139.0f : orderingTableSize_1f8003c8.get() - 4.0f;
+                  cloud.queueZ = i < 12 ? 556.0f : (orderingTableSize_1f8003c8.get() - 4.0f) * 4.0f;
                   cloud.transforms.scaling(sx1 - sx0, sy2 - sy0, 1.0f);
                   cloud.transforms.transfer.set(GPU.getOffsetX() + sx0, GPU.getOffsetY() + sy0, cloud.queueZ);
                   RENDERER.queueOrthoModel(this.wmapStruct258_800c66a8.atmosphericEffectSprites[i % 3], cloud.transforms)
@@ -6135,7 +6135,7 @@ public class WMap extends EngineState {
                 //LAB_800ed5d8
                 snowflake.snowUvIndex_50 = (snowflake.snowUvIndex_50 + 1) % 12;
                 final int index = (int)(snowflake.snowUvIndex_50 / 2.0f);
-                snowflake.transforms.transfer.set(GPU.getOffsetX() + sx0, GPU.getOffsetY() + sy0, 139.0f);
+                snowflake.transforms.transfer.set(GPU.getOffsetX() + sx0, GPU.getOffsetY() + sy0, 556.0f);
                 RENDERER.queueOrthoModel(this.wmapStruct258_800c66a8.atmosphericEffectSprites[index], snowflake.transforms)
                   .monochrome(snowflake.brightness_5c);
               }

--- a/src/main/java/legend/game/wmap/WMap.java
+++ b/src/main/java/legend/game/wmap/WMap.java
@@ -142,7 +142,7 @@ public class WMap extends EngineState {
   private int worldMapState_800c6698;
   private int playerState_800c669c;
 
-  private int smokeEffectStage_800c66a4;
+  private int atmosphericEffectStage_800c66a4;
   private final WMapStruct258 wmapStruct258_800c66a8 = new WMapStruct258();
 
   private final WMapStruct19c0 wmapStruct19c0_800c66b0 = new WMapStruct19c0();
@@ -648,7 +648,7 @@ public class WMap extends EngineState {
       gameState_800babc8.scriptFlags1_13c.setRaw(i, 0);
     }
 
-    this.FUN_800ccf04();
+    this.initWmapAudioVisuals();
     this.tickMainMenuOpenTransition_800c6690 = 0;
     pregameLoadingStage_800bb10c.set(14);
   }
@@ -784,11 +784,11 @@ public class WMap extends EngineState {
   }
 
   @Method(0x800ccf04L)
-  private void FUN_800ccf04() {
+  private void initWmapAudioVisuals() {
     this.worldMapState_800c6698 = 2;
     this.playerState_800c669c = 2;
     loadWait = 60;
-    this.smokeEffectStage_800c66a4 = 2;
+    this.atmosphericEffectStage_800c66a4 = 2;
     this.filesLoadedFlags_800c66b8.set(0);
     zOffset_1f8003e8.set(0);
     tmdGp0Tpage_1f8003ec.set(0x20);
@@ -5906,10 +5906,8 @@ public class WMap extends EngineState {
 
       //LAB_800ebe24
       cloud.snowUvIndex_50 = 0;
-      cloud.x_58 = (288 - rand() % 64) / 2;
-      cloud.y_5a = ( 80 - rand() % 32) / 2;
+      cloud.translation_58.set((288 - rand() % 64) / 2, (80 - rand() % 32) / 2, 0);
       cloud.brightness_5c = 0.0f;
-      cloud.z_5e = 0;
     }
 
     //LAB_800ebf2c
@@ -5933,10 +5931,10 @@ public class WMap extends EngineState {
       final WMapAtmosphericEffectInstance60 cloud = struct.atmosphericEffectInstances_24[i];
 
       //LAB_800ec044
-      cloud.z_5e++;
-      if(cloud.z_5e >> i % 3 + 4 != 0) {
+      cloud.translation_58.z++;
+      if(cloud.translation_58.z >> i % 3 + 4 != 0) {
         cloud.coord2_00.coord.transfer.x++;
-        cloud.z_5e = 0;
+        cloud.translation_58.z = 0;
       }
 
       //LAB_800ec288
@@ -5975,21 +5973,21 @@ public class WMap extends EngineState {
         GsGetLs(cloud.coord2_00, cloud.transforms);
         cloud.transforms.identity(); // NOTE: does not clear translation
         GTE.setTransforms(cloud.transforms);
-        GTE.perspectiveTransform(-cloud.x_58, -cloud.y_5a, 0);
+        GTE.perspectiveTransform(-cloud.translation_58.x, -cloud.translation_58.y, 0);
         final float sx0 = GTE.getScreenX(2);
         final float sy0 = GTE.getScreenY(2);
         float z = GTE.getScreenZ(3) / 4.0f;
 
         if(z >= 5 && z < orderingTableSize_1f8003c8.get() - 3) {
           //LAB_800ec534
-          GTE.perspectiveTransform(cloud.x_58, -cloud.y_5a, 0);
+          GTE.perspectiveTransform(cloud.translation_58.x, -cloud.translation_58.y, 0);
           final float sx1 = GTE.getScreenX(2);
           final float sy1 = GTE.getScreenY(2);
           z = GTE.getScreenZ(3) / 4.0f;
 
           if(z >= 5 && z < orderingTableSize_1f8003c8.get() - 3 && sx1 - sx0 <= 0x400) {
             //LAB_800ec5ec
-            GTE.perspectiveTransform(-cloud.x_58, cloud.y_5a, 0);
+            GTE.perspectiveTransform(-cloud.translation_58.x, cloud.translation_58.y, 0);
             final float sx2 = GTE.getScreenX(2);
             final float sy2 = GTE.getScreenY(2);
             z = GTE.getScreenZ(3) / 4.0f;
@@ -6023,7 +6021,7 @@ public class WMap extends EngineState {
               //LAB_800ec798
               if(!MathHelper.flEq(cloud.brightness_5c, 0.0f)) {
                 //LAB_800ec7b8
-                GTE.perspectiveTransform(cloud.x_58, cloud.y_5a, 0);
+                GTE.perspectiveTransform(cloud.translation_58.x, cloud.translation_58.y, 0);
                 final float sx3 = GTE.getScreenX(2);
                 final float sy3 = GTE.getScreenY(2);
                 z = GTE.getScreenZ(3) / 4.0f;
@@ -6075,10 +6073,8 @@ public class WMap extends EngineState {
       snowflake.coord2_00.coord.transfer.y =     - rand() %  200;
       snowflake.coord2_00.coord.transfer.z = 500 - rand() % 1000;
       snowflake.snowUvIndex_50 = rand() % 12;
-      snowflake.x_58 = rand() % 2 - 1;
-      snowflake.y_5a = rand() % 2 + 1;
+      snowflake.translation_58.set(rand() % 2 - 1, rand() % 2 + 1, rand() % 2 - 1);
       snowflake.brightness_5c = 0.0f;
-      snowflake.z_5e = rand() % 2 - 1;
     }
     //LAB_800eccfc
   }
@@ -6117,9 +6113,9 @@ public class WMap extends EngineState {
       //LAB_800ed164
       if(!MathHelper.flEq(snowflake.brightness_5c, 0.0f)) {
         //LAB_800ed184
-        snowflake.coord2_00.coord.transfer.x += snowflake.x_58 / (3.0f / vsyncMode_8007a3b8);
-        snowflake.coord2_00.coord.transfer.y += snowflake.y_5a / (3.0f / vsyncMode_8007a3b8);
-        snowflake.coord2_00.coord.transfer.z += snowflake.z_5e / (3.0f / vsyncMode_8007a3b8);
+        snowflake.coord2_00.coord.transfer.x += snowflake.translation_58.x / (3.0f / vsyncMode_8007a3b8);
+        snowflake.coord2_00.coord.transfer.y += snowflake.translation_58.y / (3.0f / vsyncMode_8007a3b8);
+        snowflake.coord2_00.coord.transfer.z += snowflake.translation_58.z / (3.0f / vsyncMode_8007a3b8);
 
         if(snowflake.coord2_00.coord.transfer.y > 0.0f) {
           snowflake.coord2_00.coord.transfer.x =  500 - rand() % 1000;
@@ -6201,25 +6197,23 @@ public class WMap extends EngineState {
     }
 
     //LAB_800ed98c
-    switch(this.smokeEffectStage_800c66a4) {
-      case 0 -> { }
-
+    switch(this.atmosphericEffectStage_800c66a4) {
       case 2 -> {
         if((this.filesLoadedFlags_800c66b8.get() & 0x1_0000) != 0 && (this.filesLoadedFlags_800c66b8.get() & 0x1000) != 0) {
-          this.smokeEffectStage_800c66a4 = 3;
+          this.atmosphericEffectStage_800c66a4 = 3;
         }
       }
 
       //LAB_800eda18
       case 3 -> {
         this.atmosphericEffectAllocators_800f65a4[this.currentWmapEffect_800f6598].run();
-        this.smokeEffectStage_800c66a4 = 4;
+        this.atmosphericEffectStage_800c66a4 = 4;
       }
 
       case 4 -> {
         if(this.worldMapState_800c6698 >= 3 || this.playerState_800c669c >= 3) {
           //LAB_800eda98
-          this.smokeEffectStage_800c66a4 = 5;
+          this.atmosphericEffectStage_800c66a4 = 5;
         }
       }
 
@@ -6229,14 +6223,14 @@ public class WMap extends EngineState {
         this.currentWmapEffect_800f6598 = (locations_800f0e34.get(this.mapState_800c6798.locationIndex_10).effectFlags_12.get() & 0x30) >>> 4;
         if(this.currentWmapEffect_800f6598 != this.previousWmapEffect_800f659c) {
           this.atmosphericEffectDeallocators_800f65bc[this.previousWmapEffect_800f659c].run();
-          this.smokeEffectStage_800c66a4 = 3;
+          this.atmosphericEffectStage_800c66a4 = 3;
         } else {
           //LAB_800edb5c
           this.atmosphericEffectRenderers_800f65b0[this.currentWmapEffect_800f6598].run();
         }
       }
 
-      default -> throw new IllegalArgumentException("Invalid index " + this.smokeEffectStage_800c66a4);
+      default -> throw new IllegalArgumentException("Invalid index " + this.atmosphericEffectStage_800c66a4);
     }
 
     //LAB_800edba4

--- a/src/main/java/legend/game/wmap/WMapAtmosphericEffectInstance60.java
+++ b/src/main/java/legend/game/wmap/WMapAtmosphericEffectInstance60.java
@@ -3,6 +3,7 @@ package legend.game.wmap;
 import legend.core.gte.GsCOORDINATE2;
 import legend.core.gte.MV;
 import legend.core.opengl.MeshObj;
+import org.joml.Vector3i;
 
 public class WMapAtmosphericEffectInstance60 {
   public static final int[] snowUs = {32, 40, 32, 40, 32, 40};
@@ -15,21 +16,15 @@ public class WMapAtmosphericEffectInstance60 {
   public final GsCOORDINATE2 coord2_00 = new GsCOORDINATE2();
   /** Originally vectro rotation_50 */
   public int snowUvIndex_50;
-  /** short */
-  public int x_58;
-  /** short */
-  public int y_5a;
+  /** Was short x_58, short y_5a, byte z_5e */
+  public final Vector3i translation_58 = new Vector3i();
   /** short */
   public float brightness_5c;
-  /** byte */
-  public int z_5e;
 
   public void set(final WMapAtmosphericEffectInstance60 other) {
     this.coord2_00.set(other.coord2_00);
     this.snowUvIndex_50 = other.snowUvIndex_50;
-    this.x_58 = other.x_58;
-    this.y_5a = other.y_5a;
+    this.translation_58.set(other.translation_58);
     this.brightness_5c = other.brightness_5c;
-    this.z_5e = other.z_5e;
   }
 }

--- a/src/main/java/legend/game/wmap/WMapAtmosphericEffectInstance60.java
+++ b/src/main/java/legend/game/wmap/WMapAtmosphericEffectInstance60.java
@@ -3,15 +3,18 @@ package legend.game.wmap;
 import legend.core.gte.GsCOORDINATE2;
 import legend.core.gte.MV;
 import legend.core.opengl.MeshObj;
-import org.joml.Vector3f;
 
 public class WMapAtmosphericEffectInstance60 {
+  public static final int[] snowUs = {32, 40, 32, 40, 32, 40};
+  public static final int[] snowVs = {16, 16, 24, 24, 24, 16};
+
   public MeshObj obj;
   public final MV transforms = new MV();
   public float queueZ;
 
   public final GsCOORDINATE2 coord2_00 = new GsCOORDINATE2();
-  public final Vector3f rotation_50 = new Vector3f();
+  /** Originally vectro rotation_50 */
+  public int snowUvIndex_50;
   /** short */
   public int x_58;
   /** short */
@@ -23,7 +26,7 @@ public class WMapAtmosphericEffectInstance60 {
 
   public void set(final WMapAtmosphericEffectInstance60 other) {
     this.coord2_00.set(other.coord2_00);
-    this.rotation_50.set(other.rotation_50);
+    this.snowUvIndex_50 = other.snowUvIndex_50;
     this.x_58 = other.x_58;
     this.y_5a = other.y_5a;
     this.brightness_5c = other.brightness_5c;

--- a/src/main/java/legend/game/wmap/WMapAtmosphericEffectInstance60.java
+++ b/src/main/java/legend/game/wmap/WMapAtmosphericEffectInstance60.java
@@ -1,15 +1,17 @@
 package legend.game.wmap;
 
+import legend.core.gpu.Bpp;
 import legend.core.gte.GsCOORDINATE2;
 import legend.core.gte.MV;
 import legend.core.opengl.MeshObj;
+import legend.core.opengl.QuadBuilder;
+import legend.game.types.Translucency;
 import org.joml.Vector3i;
 
 public class WMapAtmosphericEffectInstance60 {
   public static final int[] snowUs = {32, 40, 32, 40, 32, 40};
   public static final int[] snowVs = {16, 16, 24, 24, 24, 16};
 
-  public MeshObj obj;
   public final MV transforms = new MV();
   public float queueZ;
 
@@ -26,5 +28,39 @@ public class WMapAtmosphericEffectInstance60 {
     this.snowUvIndex_50 = other.snowUvIndex_50;
     this.translation_58.set(other.translation_58);
     this.brightness_5c = other.brightness_5c;
+  }
+
+  public static MeshObj[] buildCloudSprites() {
+    final MeshObj[] cloudArray = new MeshObj[3];
+    for(int i = 0; i < 3; i++) {
+      cloudArray[i] = new QuadBuilder("Cloud (index " + i + ')')
+        .bpp(Bpp.BITS_4)
+        .clut(576, 496 + i % 3)
+        .vramPos(576, 256)
+        .size(1.0f, 1.0f)
+        .uv(0, i % 3 * 64)
+        .uvSize(255, 64)
+        .translucency(Translucency.B_PLUS_F)
+        .build();
+    }
+
+    return cloudArray;
+  }
+
+  public static MeshObj[] buildSnowSprites() {
+    final MeshObj[] snowArray = new MeshObj[6];
+    for(int i = 0; i < 6; i++) {
+      snowArray[i] = new QuadBuilder("Snowflake (index " + i + ')')
+        .bpp(Bpp.BITS_4)
+        .clut(640, 496)
+        .vramPos(640, 256)
+        .size(2.0f, 2.0f)
+        .uv(WMapAtmosphericEffectInstance60.snowUs[i], WMapAtmosphericEffectInstance60.snowVs[i])
+        .uvSize(8, 8)
+        .translucency(Translucency.B_PLUS_F)
+        .build();
+    }
+
+    return snowArray;
   }
 }

--- a/src/main/java/legend/game/wmap/WMapStruct258.java
+++ b/src/main/java/legend/game/wmap/WMapStruct258.java
@@ -19,11 +19,14 @@ public class WMapStruct258 {
   public TextureAnimation20 textureAnimation_1c;
   /** short */
   public float colour_20;
+
   public MeshObj mapOverlayObj;
-  public MeshObj zoomOverlayObjs[] = new MeshObj[7];
+  public MeshObj[] zoomOverlayObjs = new MeshObj[7];
   public final MV mapOverlayTransforms = new MV();
 
   public WMapAtmosphericEffectInstance60[] atmosphericEffectInstances_24;
+  public MeshObj[] atmosphericEffectSprites;
+
   public float clutYIndex_28;
   public FileData imageData_2c;
   public FileData imageData_30;
@@ -82,9 +85,9 @@ public class WMapStruct258 {
   public int _254;
 
   public void deleteAtmosphericEffectObjs() {
-    for(final WMapAtmosphericEffectInstance60 effect : this.atmosphericEffectInstances_24) {
-      if(effect.obj != null) {
-        effect.obj.delete();
+    for(final MeshObj obj : this.atmosphericEffectSprites) {
+      if(obj != null) {
+        obj.delete();
       }
     }
   }


### PR DESCRIPTION
Refactored some of the stuff around WmapAtmosphericEffectInstance60 and WmapStruct258 to only build the weather effect sprites once at allocation instead of for each instance, which applies to both snow and clouds. Also combined the deallocators, removed some more statics, and refactored a few translation attributes.

Closes #762 