### PR TITLE
More renaming and teleportation fix

### DIFF
--- a/src/main/java/legend/game/Scus94491BpeSegment_8005.java
+++ b/src/main/java/legend/game/Scus94491BpeSegment_8005.java
@@ -59,6 +59,7 @@ public final class Scus94491BpeSegment_8005 {
   public static final LodString _80052c20 = MEMORY.ref(2, 0x80052c20L, LodString::new);
   public static final IntRef submapCut_80052c30 = MEMORY.ref(4, 0x80052c30L, IntRef::new);
   public static final IntRef submapScene_80052c34 = MEMORY.ref(4, 0x80052c34L, IntRef::new);
+  /** TODO This seems like it's set to a lot of different things, hopefully they're actually related. */
   public static final IntRef index_80052c38 = MEMORY.ref(4, 0x80052c38L, IntRef::new);
   public static final IntRef submapCut_80052c3c = MEMORY.ref(4, 0x80052c3cL, IntRef::new);
   /** Moved from SMAP since it's referenced unconditionally when saving the game */

--- a/src/main/java/legend/game/wmap/MapState100.java
+++ b/src/main/java/legend/game/wmap/MapState100.java
@@ -100,7 +100,7 @@ public class MapState100 {
   public boolean disableInput_d0;
   /** Used to move player away from location when exiting entrance prompt or leaving location (800c686c) */
   public ForcedMovementState shortForceMovementState_d4;
-  /** Used specifically for when the Queen Fury is force sailed the first time (800c6870) */
+  /** Used specifically for when the Queen Fury is force-sailed the first time (800c6870) */
   public ForcedMovementState queenFuryForceMovementState_d8;
   /**
    * 800c6874

--- a/src/main/java/legend/game/wmap/MapState100.java
+++ b/src/main/java/legend/game/wmap/MapState100.java
@@ -7,6 +7,13 @@ import org.joml.Vector3f;
 import java.util.Arrays;
 
 public class MapState100 {
+  public enum ForcedMovementState {
+    NONE,
+    WALK,
+    RUN,
+    FADE_OUT
+  }
+
   public enum PathSegmentEntering {
     CURRENT,
     PREVIOUS,
@@ -91,10 +98,10 @@ public class MapState100 {
 
   /** 800c6868 */
   public boolean disableInput_d0;
-  /** 800c686c */
-  public int _d4;
-  /** 800c6870 */
-  public int _d8;
+  /** Used to move player away from location when exiting entrance prompt or leaving location (800c686c) */
+  public ForcedMovementState shortForceMovementState_d4;
+  /** Used specifically for when the Queen Fury is force sailed the first time (800c6870) */
+  public ForcedMovementState queenFuryForceMovementState_d8;
   /**
    * 800c6874
    * Array of temp indices of paths branching off a location point

--- a/src/main/java/legend/game/wmap/WMap.java
+++ b/src/main/java/legend/game/wmap/WMap.java
@@ -127,6 +127,7 @@ import static legend.game.wmap.MapState100.PathSegmentEntering;
 import static legend.game.wmap.MapState100.PathSegmentEndpointType;
 import static legend.game.wmap.MapState100.ForcedMovementState;
 import static legend.game.wmap.WMapStruct258.FadeState;
+import static legend.game.wmap.WMapStruct258.TeleportAnimationState;
 import static legend.game.wmap.WMapStruct258.TransitionAnimationType;
 import static legend.game.wmap.WMapStruct258.MapTransitionDestinationMode;
 import static legend.game.wmap.WmapStatics.coolonWarpDest_800ef228;
@@ -3083,7 +3084,7 @@ public class WMap extends EngineState {
     }
 
     //LAB_800dfbb4
-    this.wmapStruct258_800c66a8._248 = 0;
+    this.wmapStruct258_800c66a8.teleportAnimationState_248 = TeleportAnimationState.INIT_ANIM;
   }
 
   @Method(0x800dfbd8L)
@@ -3232,11 +3233,11 @@ public class WMap extends EngineState {
     } else if(this.wmapStruct258_800c66a8.mapTransitionDestinationMode_250 == MapTransitionDestinationMode.TELEPORT) {
       //LAB_800e0770
       //LAB_800e0774
-      int locationIndex = 0;
+      int targetLocationIndex = 0;
       for(int i = 0; i < 6; i++) {
         //LAB_800e0790
         if(this.mapState_800c6798.locationIndex_10 == teleportationEndpoints_800ef698.get(i).originLocationIndex_00.get()) {
-          locationIndex = teleportationEndpoints_800ef698.get(i).targetLocationIndex_04.get();
+          targetLocationIndex = teleportationEndpoints_800ef698.get(i).targetLocationIndex_04.get();
           break;
         }
       }
@@ -3245,57 +3246,62 @@ public class WMap extends EngineState {
       final Vector3f originTranslation = new Vector3f();
       final Vector3f targetTranslation = new Vector3f();
       this.getTeleportationLocationTranslation(this.mapState_800c6798.locationIndex_10, originTranslation);
-      this.getTeleportationLocationTranslation(locationIndex, targetTranslation);
+      this.getTeleportationLocationTranslation(targetLocationIndex, targetTranslation);
 
       //LAB_800e0878
-      if(this.wmapStruct258_800c66a8._248 == 0 || this.wmapStruct258_800c66a8._248 == 1) {
-        if(this.wmapStruct258_800c66a8._248 == 0) {
+      final float scale;
+      switch(this.wmapStruct258_800c66a8.teleportAnimationState_248) {
+        case INIT_ANIM:
           //LAB_800e0898
-          this.wmapStruct258_800c66a8._24c = 0;
-          this.wmapStruct258_800c66a8._248 = 1;
-        }
+          this.wmapStruct258_800c66a8.teleportAnimationTick_24c = 0;
+          this.wmapStruct258_800c66a8.teleportAnimationState_248 = TeleportAnimationState.RENDER_ANIM;
 
-        //LAB_800e08b8
-        this.renderWinglyTeleportScreenEffect();
+        case RENDER_ANIM:
+          //LAB_800e08b8
+          this.renderWinglyTeleportScreenEffect();
 
-        this.lerpish(this.wmapStruct258_800c66a8.currPlayerPos_94, originTranslation, targetTranslation, 32.0f / this.wmapStruct258_800c66a8._24c);
+          this.lerpish(this.wmapStruct258_800c66a8.currPlayerPos_94, originTranslation, targetTranslation, 32.0f / this.wmapStruct258_800c66a8.teleportAnimationTick_24c);
 
-        this.wmapStruct258_800c66a8._24c++;
-        if(this.wmapStruct258_800c66a8._24c > 32) {
-          this.wmapStruct258_800c66a8._248 = 2;
-        }
+          this.wmapStruct258_800c66a8.teleportAnimationTick_24c++;
+          if(this.wmapStruct258_800c66a8.teleportAnimationTick_24c > 32) {
+            this.wmapStruct258_800c66a8.teleportAnimationState_248 = TeleportAnimationState.INIT_FADE;
+          }
 
-        //LAB_800e0980
-        final float scale = this.wmapStruct258_800c66a8._24c * 0x40 + (rsin(this.wmapStruct258_800c66a8._24c * 0x200) * 0x100 >> 12) / (float)0x1000;
-        this.wmapStruct258_800c66a8.models_0c[3].coord2_14.transforms.scale.set(scale, scale, scale);
-        this.wmapStruct258_800c66a8.models_0c[this.wmapStruct258_800c66a8.modelIndex_1e4].coord2_14.transforms.rotate.y = this.wmapStruct19c0_800c66b0.mapRotation_70.y;
-        this.wmapStruct258_800c66a8.rotation_a4.y = this.wmapStruct19c0_800c66b0.mapRotation_70.y;
-      } else if(this.wmapStruct258_800c66a8._248 == 2) {
-        //LAB_800e0a6c
-        gameState_800babc8.visitedLocations_17c.set(locationIndex, true);
+          //LAB_800e0980
+          scale = this.wmapStruct258_800c66a8.teleportAnimationTick_24c * 0x40 + (rsin(this.wmapStruct258_800c66a8.teleportAnimationTick_24c * 0x200) * 0x100 >> 12) / (float)0x1000;
+          this.wmapStruct258_800c66a8.models_0c[3].coord2_14.transforms.scale.set(scale, scale, scale);
+          this.wmapStruct258_800c66a8.models_0c[this.wmapStruct258_800c66a8.modelIndex_1e4].coord2_14.transforms.rotate.y = this.wmapStruct19c0_800c66b0.mapRotation_70.y;
+          this.wmapStruct258_800c66a8.rotation_a4.y = this.wmapStruct19c0_800c66b0.mapRotation_70.y;
+          break;
 
-        //LAB_800e0b64
-        this.mapState_800c6798.submapCut_c8 = locations_800f0e34[locationIndex].submapCut_08;
-        this.mapState_800c6798.submapScene_ca = locations_800f0e34[locationIndex].submapScene_0a;
-        submapCut_80052c30.set(this.mapState_800c6798.submapCut_c8);
-        submapScene_80052c34.set(this.mapState_800c6798.submapScene_ca);
+        case INIT_FADE:
+          //LAB_800e0a6c
+          gameState_800babc8.visitedLocations_17c.set(targetLocationIndex, true);
 
-        this.initTransitionAnimation(TransitionAnimationType.FADE_OUT);
-        this.wmapStruct258_800c66a8._248 = 3;
-      } else if(this.wmapStruct258_800c66a8._248 == 3) {
-        //LAB_800e0c00
-        this.wmapStruct258_800c66a8.models_0c[3].coord2_14.transforms.scale.x -= 0.25f / (3.0f / vsyncMode_8007a3b8);
+          //LAB_800e0b64
+          this.mapState_800c6798.submapCut_c8 = locations_800f0e34[targetLocationIndex].submapCut_08;
+          this.mapState_800c6798.submapScene_ca = locations_800f0e34[targetLocationIndex].submapScene_0a;
+          submapCut_80052c30.set(this.mapState_800c6798.submapCut_c8);
+          submapScene_80052c34.set(this.mapState_800c6798.submapScene_ca);
 
-        if(this.wmapStruct258_800c66a8.models_0c[3].coord2_14.transforms.scale.x < 0.0f) {
-          this.wmapStruct258_800c66a8.models_0c[3].coord2_14.transforms.scale.x = 0.0f;
-        }
+          this.initTransitionAnimation(TransitionAnimationType.FADE_OUT);
+          this.wmapStruct258_800c66a8.teleportAnimationState_248 = TeleportAnimationState.FADE_OUT;
+          break;
 
-        //LAB_800e0c70
-        final float a0 = this.wmapStruct258_800c66a8.models_0c[3].coord2_14.transforms.scale.x;
-        this.wmapStruct258_800c66a8.models_0c[3].coord2_14.transforms.scale.y = a0;
-        this.wmapStruct258_800c66a8.models_0c[3].coord2_14.transforms.scale.z = a0;
+        case FADE_OUT:
+          //LAB_800e0c00
+          this.wmapStruct258_800c66a8.models_0c[3].coord2_14.transforms.scale.x -= 0.25f / (3.0f / vsyncMode_8007a3b8);
+
+          if(this.wmapStruct258_800c66a8.models_0c[3].coord2_14.transforms.scale.x < 0.0f) {
+            this.wmapStruct258_800c66a8.models_0c[3].coord2_14.transforms.scale.x = 0.0f;
+          }
+
+          //LAB_800e0c70
+          scale = this.wmapStruct258_800c66a8.models_0c[3].coord2_14.transforms.scale.x;
+          this.wmapStruct258_800c66a8.models_0c[3].coord2_14.transforms.scale.y = scale;
+          this.wmapStruct258_800c66a8.models_0c[3].coord2_14.transforms.scale.z = scale;
+          break;
       }
-
       //LAB_800e0cbc
     }
 

--- a/src/main/java/legend/game/wmap/WMap.java
+++ b/src/main/java/legend/game/wmap/WMap.java
@@ -123,13 +123,13 @@ import static legend.game.Scus94491BpeSegment_800b.tickCount_800bb0fc;
 import static legend.game.Scus94491BpeSegment_800b.whichMenu_800bdc38;
 import static legend.game.Scus94491BpeSegment_800c.lightColourMatrix_800c3508;
 import static legend.game.Scus94491BpeSegment_800c.lightDirectionMatrix_800c34e8;
-import static legend.game.wmap.MapState100.PathSegmentEntering;
-import static legend.game.wmap.MapState100.PathSegmentEndpointType;
 import static legend.game.wmap.MapState100.ForcedMovementState;
+import static legend.game.wmap.MapState100.PathSegmentEndpointType;
+import static legend.game.wmap.MapState100.PathSegmentEntering;
 import static legend.game.wmap.WMapStruct258.FadeState;
+import static legend.game.wmap.WMapStruct258.MapTransitionDestinationType;
 import static legend.game.wmap.WMapStruct258.TeleportAnimationState;
 import static legend.game.wmap.WMapStruct258.TransitionAnimationType;
-import static legend.game.wmap.WMapStruct258.MapTransitionDestinationMode;
 import static legend.game.wmap.WmapStatics.coolonWarpDest_800ef228;
 import static legend.game.wmap.WmapStatics.directionalPathSegmentData_800f2248;
 import static legend.game.wmap.WmapStatics.encounterIds_800ef364;
@@ -485,7 +485,7 @@ public class WMap extends EngineState {
                       if(this.mapState_800c6798.pathSegmentEndpointTypeCrossed_fc != PathSegmentEndpointType.TERMINAL) {
                         if(struct.transitionAnimationType_05 == TransitionAnimationType.NONE) {
                           if(this.mapState_800c6798.queenFuryForceMovementState_d8 == ForcedMovementState.NONE) {
-                            if(struct.mapTransitionDestinationMode_250 == MapTransitionDestinationMode.NONE) {
+                            if(struct.mapTransitionDestinationType_250 == MapTransitionDestinationType.NONE) {
                               startFadeEffect(1, 15);
                               this.mapState_800c6798.disableInput_d0 = true;
                               this.tickMainMenuOpenTransition_800c6690 = 1;
@@ -1121,12 +1121,12 @@ public class WMap extends EngineState {
 
   @Method(0x800d2fa8L)
   private void handleMapRotation() {
-    if(this.wmapStruct258_800c66a8.mapTransitionDestinationMode_250 == MapTransitionDestinationMode.TELEPORT) {
+    if(this.wmapStruct258_800c66a8.mapTransitionDestinationType_250 == MapTransitionDestinationType.TELEPORT) {
       //LAB_800d401c
       this.wmapStruct19c0_800c66b0.mapRotation_70.y += MathHelper.psxDegToRad(8) / (3.0f / vsyncMode_8007a3b8);
     } else {
       //LAB_800d2fd4
-      if(this.wmapStruct258_800c66a8.mapTransitionDestinationMode_250 == MapTransitionDestinationMode.SUBMAP && this.wmapStruct258_800c66a8.transitionAnimationType_05 == TransitionAnimationType.NONE) {
+      if(this.wmapStruct258_800c66a8.mapTransitionDestinationType_250 == MapTransitionDestinationType.SUBMAP && this.wmapStruct258_800c66a8.transitionAnimationType_05 == TransitionAnimationType.NONE) {
         return;
       }
 
@@ -1956,7 +1956,7 @@ public class WMap extends EngineState {
     }
 
     //LAB_800d692c
-    if(this.wmapStruct258_800c66a8.mapTransitionDestinationMode_250 == MapTransitionDestinationMode.SUBMAP) {
+    if(this.wmapStruct258_800c66a8.mapTransitionDestinationType_250 == MapTransitionDestinationType.SUBMAP) {
       return;
     }
 
@@ -2332,7 +2332,7 @@ public class WMap extends EngineState {
     }
 
     //LAB_800d951c
-    if(this.wmapStruct258_800c66a8.mapTransitionDestinationMode_250 != MapTransitionDestinationMode.NONE) {
+    if(this.wmapStruct258_800c66a8.mapTransitionDestinationType_250 != MapTransitionDestinationType.NONE) {
       return;
     }
 
@@ -2539,7 +2539,7 @@ public class WMap extends EngineState {
     }
 
     //LAB_800da420
-    if(struct.mapTransitionDestinationMode_250 == MapTransitionDestinationMode.TELEPORT) {
+    if(struct.mapTransitionDestinationType_250 == MapTransitionDestinationType.TELEPORT) {
       return;
     }
 
@@ -2555,11 +2555,11 @@ public class WMap extends EngineState {
     if(Input.pressedThisFrame(InputAction.BUTTON_WEST)) { // Square
       this.destinationLabelStage_800c86f0 = 0;
       this.shouldSetCoolonWarpDestLabelMetrics = true;
-      struct.mapTransitionDestinationMode_250 = MapTransitionDestinationMode.SUBMAP;
+      struct.mapTransitionDestinationType_250 = MapTransitionDestinationType.SUBMAP;
     }
 
     //LAB_800da520
-    if(struct.mapTransitionDestinationMode_250 != MapTransitionDestinationMode.SUBMAP) {
+    if(struct.mapTransitionDestinationType_250 != MapTransitionDestinationType.SUBMAP) {
       return;
     }
 
@@ -2747,6 +2747,7 @@ public class WMap extends EngineState {
         this.renderCoolonMap(false, true);
         break;
 
+      // TODO Refactor Coolon prompt code a bit to work more like location prompt
       case 6:
         textboxes_800be358[6].z_0c = 18;
 
@@ -2824,7 +2825,7 @@ public class WMap extends EngineState {
           this.mapState_800c6798.submapScene_ca = locations_800f0e34[coolonWarpDest_800ef228[struct.coolonWarpIndex_222].locationIndex_10].submapScene_06;
           submapCut_80052c30.set(this.mapState_800c6798.submapCut_c8);
           index_80052c38.set(this.mapState_800c6798.submapScene_ca);
-          struct.mapTransitionDestinationMode_250 = MapTransitionDestinationMode.WORLD_MAP;
+          struct.mapTransitionDestinationType_250 = MapTransitionDestinationType.WORLD_MAP;
           previousEngineState_8004dd28 = null;
         }
 
@@ -2915,7 +2916,7 @@ public class WMap extends EngineState {
 
         this.wmapStruct19c0_800c66b0.mapRotation_70.y = struct.angle_21e;
 
-        struct.mapTransitionDestinationMode_250 = MapTransitionDestinationMode.NONE;
+        struct.mapTransitionDestinationType_250 = MapTransitionDestinationType.NONE;
         struct._220 = 0;
         return;
     }
@@ -3163,7 +3164,7 @@ public class WMap extends EngineState {
   private void renderPlayer() {
     final WMapStruct258 struct = this.wmapStruct258_800c66a8;
 
-    if(struct.mapTransitionDestinationMode_250 != MapTransitionDestinationMode.SUBMAP) {
+    if(struct.mapTransitionDestinationType_250 != MapTransitionDestinationType.SUBMAP) {
       struct.modelIndex_1e4 = directionalPathSegmentData_800f2248.get(this.mapState_800c6798.directionalPathIndex_12).modelIndex_06.get();
 
       assert struct.modelIndex_1e4 < 4;
@@ -3227,10 +3228,10 @@ public class WMap extends EngineState {
   private void FUN_800e06d0() {
     this.wmapStruct258_800c66a8.prevPlayerPos_84.set(this.wmapStruct258_800c66a8.currPlayerPos_94);
 
-    if(this.wmapStruct258_800c66a8.mapTransitionDestinationMode_250 == MapTransitionDestinationMode.NONE) {
+    if(this.wmapStruct258_800c66a8.mapTransitionDestinationType_250 == MapTransitionDestinationType.NONE) {
       //LAB_800e0760
       this.FUN_800e8a10();
-    } else if(this.wmapStruct258_800c66a8.mapTransitionDestinationMode_250 == MapTransitionDestinationMode.TELEPORT) {
+    } else if(this.wmapStruct258_800c66a8.mapTransitionDestinationType_250 == MapTransitionDestinationType.TELEPORT) {
       //LAB_800e0770
       //LAB_800e0774
       int targetLocationIndex = 0;
@@ -3403,7 +3404,7 @@ public class WMap extends EngineState {
     struct.coord2_34.coord.transfer.set(struct.currPlayerPos_94);
     struct.models_0c[struct.modelIndex_1e4].coord2_14.coord.transfer.set(struct.coord2_34.coord.transfer);
 
-    if(struct.mapTransitionDestinationMode_250 == MapTransitionDestinationMode.NONE) {
+    if(struct.mapTransitionDestinationType_250 == MapTransitionDestinationType.NONE) {
       float sp10 = struct.rotation_a4.y - struct.models_0c[struct.modelIndex_1e4].coord2_14.transforms.rotate.y;
       final float sp14 = struct.rotation_a4.y - (struct.models_0c[struct.modelIndex_1e4].coord2_14.transforms.rotate.y - MathHelper.TWO_PI);
 
@@ -3812,7 +3813,7 @@ public class WMap extends EngineState {
   @Method(0x800e406cL)
   private void tickFadeInTransition() {
     final WMapStruct258 struct = this.wmapStruct258_800c66a8;
-    if(struct.mapTransitionDestinationMode_250 == MapTransitionDestinationMode.TELEPORT) {
+    if(struct.mapTransitionDestinationType_250 == MapTransitionDestinationType.TELEPORT) {
       //LAB_800e442c
       switch(struct.fadeState_04) {
         case START_FADE:
@@ -3865,8 +3866,8 @@ public class WMap extends EngineState {
           break;
       }
     } else if(
-      struct.mapTransitionDestinationMode_250 == MapTransitionDestinationMode.NONE ||
-        struct.mapTransitionDestinationMode_250 == MapTransitionDestinationMode.SUBMAP
+      struct.mapTransitionDestinationType_250 == MapTransitionDestinationType.NONE ||
+        struct.mapTransitionDestinationType_250 == MapTransitionDestinationType.SUBMAP
     ) {
       switch(struct.fadeState_04) {
         case START_FADE:
@@ -3984,10 +3985,10 @@ public class WMap extends EngineState {
             }
 
             //LAB_800e48c4
-            if(struct.mapTransitionDestinationMode_250 == MapTransitionDestinationMode.SUBMAP) {
+            if(struct.mapTransitionDestinationType_250 == MapTransitionDestinationType.SUBMAP) {
               this.wmapState_800bb10c = WmapState.TRANSITION_TO_SUBMAP_7;
               //LAB_800e48f4
-            } else if(struct.mapTransitionDestinationMode_250 == MapTransitionDestinationMode.WORLD_MAP) {
+            } else if(struct.mapTransitionDestinationType_250 == MapTransitionDestinationType.WORLD_MAP) {
               this.wmapState_800bb10c = WmapState.TRANSITION_TO_WORLD_MAP_9;
             }
           }
@@ -4670,7 +4671,7 @@ public class WMap extends EngineState {
 
     //LAB_800e7b44
     //LAB_800e7b54
-    boolean locationFound = false;
+    boolean locationExists = false;
     int locationIndex;
     for(locationIndex = 0; locationIndex < 0x100; locationIndex++) {
       //LAB_800e7b70
@@ -4678,7 +4679,7 @@ public class WMap extends EngineState {
         locations_800f0e34[locationIndex].submapCut_04 == this.mapState_800c6798.submapCut_c4 &&
           locations_800f0e34[locationIndex].submapScene_06 == this.mapState_800c6798.submapScene_c6
       ) {
-        locationFound = true;
+        locationExists = true;
         break;
       }
       //LAB_800e7bc0
@@ -4686,7 +4687,7 @@ public class WMap extends EngineState {
 
     //LAB_800e7be8
     //LAB_800e7c18
-    if(!locationFound || !gameState_800babc8.wmapFlags_15c.get(locationIndex)) {
+    if(!locationExists || !gameState_800babc8.wmapFlags_15c.get(locationIndex)) {
       this.mapState_800c6798.submapCut_c4 = 13; // Hellena
       this.mapState_800c6798.submapScene_c6 = 17;
       locationIndex = 5;
@@ -4861,7 +4862,7 @@ public class WMap extends EngineState {
     }
 
     //LAB_800e8720
-    this.wmapStruct258_800c66a8.mapTransitionDestinationMode_250 = MapTransitionDestinationMode.NONE;
+    this.wmapStruct258_800c66a8.mapTransitionDestinationType_250 = MapTransitionDestinationType.NONE;
     this.wmapStruct258_800c66a8.usingCoolonFromZenebatos_254 = false;
 
     //LAB_800e8770
@@ -4877,12 +4878,12 @@ public class WMap extends EngineState {
         this.mapState_800c6798.submapCut_c4 == 572 && this.mapState_800c6798.submapScene_c6 == 23     // Aglis to Zenebatos
     ) {
       //LAB_800e8830
-      this.wmapStruct258_800c66a8.mapTransitionDestinationMode_250 = MapTransitionDestinationMode.TELEPORT;
+      this.wmapStruct258_800c66a8.mapTransitionDestinationType_250 = MapTransitionDestinationType.TELEPORT;
       //LAB_800e8848
 
       // Zenebatos to Coolon map
     } else if(this.mapState_800c6798.submapCut_c4 == 529 && this.mapState_800c6798.submapScene_c6 == 41) {
-      this.wmapStruct258_800c66a8.mapTransitionDestinationMode_250 = MapTransitionDestinationMode.SUBMAP;
+      this.wmapStruct258_800c66a8.mapTransitionDestinationType_250 = MapTransitionDestinationType.SUBMAP;
       this.wmapStruct258_800c66a8.usingCoolonFromZenebatos_254 = true;
       gameState_800babc8.visitedLocations_17c.set(this.mapState_800c6798.locationIndex_10, true);
     }
@@ -5586,9 +5587,7 @@ public class WMap extends EngineState {
     final Vector3f sp0x50 = new Vector3f();
     final Vector3f[] sp0x60 = new Vector3f[0x101];
 
-    for(int i = 0; i < sp0x60.length; i++) {
-      sp0x60[i] = new Vector3f();
-    }
+    Arrays.setAll(sp0x60, i -> new Vector3f());
 
     //LAB_800eb420
     //LAB_800eb424
@@ -5655,7 +5654,6 @@ public class WMap extends EngineState {
           effectCount++;
         }
       }
-
       //LAB_800eb8dc
     }
 

--- a/src/main/java/legend/game/wmap/WMap.java
+++ b/src/main/java/legend/game/wmap/WMap.java
@@ -2347,9 +2347,9 @@ public class WMap extends EngineState {
           playSound(0, 4, 0, 0, (short)0, (short)0);
           this.shouldSetDestLabelMetrics = true;
 
-          this.wmapStruct258_800c66a8.svec_1e8.set(this.wmapStruct19c0_800c66b0.coord2_20.coord.transfer);
+          this.wmapStruct258_800c66a8.mapPosition_1e8.set(this.wmapStruct19c0_800c66b0.coord2_20.coord.transfer);
 
-          this.FUN_800d9d24(1);
+          this.initMapModelZoom(1);
 
           this.wmapStruct258_800c66a8.zoomState_1f8 = 2;
           this.mcqBrightness_800ef1a4 = 0.0f;
@@ -2367,7 +2367,7 @@ public class WMap extends EngineState {
         }
 
         //LAB_800d96b8
-        this.FUN_800d9eb0();
+        this.tickMapPositionDuringZoom();
 
         this.wmapStruct258_800c66a8.zoomAnimationTick_1f9++;
 
@@ -2404,7 +2404,7 @@ public class WMap extends EngineState {
         //LAB_800d98a8
         if(Input.pressedThisFrame(InputAction.BUTTON_SHOULDER_LEFT_2)) { // Zoom in
           playSound(0, 4, 0, 0, (short)0, (short)0);
-          this.FUN_800d9d24(-1);
+          this.initMapModelZoom(-1);
 
           this.wmapStruct258_800c66a8.zoomState_1f8 = 5;
 
@@ -2442,12 +2442,12 @@ public class WMap extends EngineState {
         }
 
         //LAB_800d9b18
-        this.FUN_800d9eb0();
+        this.tickMapPositionDuringZoom();
 
         this.wmapStruct258_800c66a8.zoomAnimationTick_1f9++;
 
         if(this.wmapStruct258_800c66a8.zoomAnimationTick_1f9 >= 18 / vsyncMode_8007a3b8) {
-          this.wmapStruct19c0_800c66b0.coord2_20.coord.transfer.set(this.wmapStruct258_800c66a8.svec_1e8);
+          this.wmapStruct19c0_800c66b0.coord2_20.coord.transfer.set(this.wmapStruct258_800c66a8.mapPosition_1e8);
           this.wmapStruct258_800c66a8.mapArrow.setSize(16.0f);
           this.wmapStruct258_800c66a8.zoomState_1f8 = 6;
         }
@@ -2468,18 +2468,18 @@ public class WMap extends EngineState {
    * @param zoomDirection -1 or +1
    */
   @Method(0x800d9d24L)
-  private void FUN_800d9d24(final int zoomDirection) {
+  private void initMapModelZoom(final int zoomDirection) {
     final Vector3i vec = mapPositions_800ef1a8[this.mapState_800c6798.continent_00.ordinal()];
-    final WMapStruct258 wmap = this.wmapStruct258_800c66a8;
-    wmap.svec_1f0.x = (vec.x - wmap.svec_1e8.x) * zoomDirection / 6.0f / (3.0f / vsyncMode_8007a3b8);
-    wmap.svec_1f0.y = (vec.y - wmap.svec_1e8.y) * zoomDirection / 6.0f / (3.0f / vsyncMode_8007a3b8);
-    wmap.svec_1f0.z = (vec.z - wmap.svec_1e8.z) * zoomDirection / 6.0f / (3.0f / vsyncMode_8007a3b8);
-    wmap.zoomAnimationTick_1f9 = 0;
+    final WMapStruct258 struct = this.wmapStruct258_800c66a8;
+    struct.mapZoomStep_1f0.x = (vec.x - struct.mapPosition_1e8.x) * zoomDirection / 6.0f / (3.0f / vsyncMode_8007a3b8);
+    struct.mapZoomStep_1f0.y = (vec.y - struct.mapPosition_1e8.y) * zoomDirection / 6.0f / (3.0f / vsyncMode_8007a3b8);
+    struct.mapZoomStep_1f0.z = (vec.z - struct.mapPosition_1e8.z) * zoomDirection / 6.0f / (3.0f / vsyncMode_8007a3b8);
+    struct.zoomAnimationTick_1f9 = 0;
   }
 
   @Method(0x800d9eb0L)
-  private void FUN_800d9eb0() {
-    this.wmapStruct19c0_800c66b0.coord2_20.coord.transfer.add(this.wmapStruct258_800c66a8.svec_1f0);
+  private void tickMapPositionDuringZoom() {
+    this.wmapStruct19c0_800c66b0.coord2_20.coord.transfer.add(this.wmapStruct258_800c66a8.mapZoomStep_1f0);
   }
 
   /** Handles Coolon fast travel, Queen Fury overlay, probably other things */
@@ -2571,7 +2571,7 @@ public class WMap extends EngineState {
         struct.svec_208.set(struct.currPlayerPos_94);
         struct.angle_21c = struct.rotation_a4.y;
         struct.angle_21e = this.wmapStruct19c0_800c66b0.mapRotation_70.y;
-        struct._223 = 0;
+        struct.coolonPromptIndex_223 = 0;
         struct._220 = 1;
         struct.models_0c[2].coord2_14.transforms.rotate.set(0.0f, struct.rotation_a4.y, 0.0f);
         struct.models_0c[2].coord2_14.transforms.scale.x = 0.25f;
@@ -2738,7 +2738,7 @@ public class WMap extends EngineState {
 
         if(isTextboxInState6(6)) {
           struct._220 = 5;
-          struct._223 = 0;
+          struct.coolonPromptIndex_223 = 0;
           struct._218 = 0;
         }
 
@@ -2761,12 +2761,12 @@ public class WMap extends EngineState {
         if(Input.pressedThisFrame(InputAction.DPAD_UP) || Input.pressedThisFrame(InputAction.JOYSTICK_LEFT_BUTTON_UP) ||
           Input.pressedThisFrame(InputAction.DPAD_DOWN) || Input.pressedThisFrame(InputAction.JOYSTICK_LEFT_BUTTON_DOWN)) {
           playSound(0, 1, 0, 0, (short)0, (short)0);
-          struct._223 ^= 1;
+          struct.coolonPromptIndex_223 ^= 1;
         }
 
         //LAB_800db3f8
         if(Input.pressedThisFrame(InputAction.BUTTON_SOUTH)) {
-          if(struct._223 == 0) {
+          if(struct.coolonPromptIndex_223 == 0) {
             playSound(0, 3, 0, 0, (short)0, (short)0);
             FUN_8002a3ec(6, 1);
             struct._220 = 3;
@@ -2779,7 +2779,7 @@ public class WMap extends EngineState {
         }
 
         //LAB_800db4b4
-        this.coolonPromptPopup.getSelector().y_3a = struct._223 * 0x10;
+        this.coolonPromptPopup.getSelector().y_3a = struct.coolonPromptIndex_223 * 0x10;
 
         break;
 

--- a/src/main/java/legend/game/wmap/WMap.java
+++ b/src/main/java/legend/game/wmap/WMap.java
@@ -4775,15 +4775,12 @@ public class WMap extends EngineState {
       for(int i = 0; i < this.mapState_800c6798.locationCount_08; i++) {
         //LAB_800e7f24
         final int directionalPathIndex = locations_800f0e34[i].directionalPathIndex_00;
-
-        if(directionalPathIndex != -1) {
           //LAB_800e7f68
-          if(this.checkLocationIsValidAndOptionallySetPathStart(i, -1, null) == 0) {
-            //LAB_800e7f88
-            if(directionalPathIndex == this.mapState_800c6798.directionalPathIndex_12) {
-              locationIndex = i;
-              break;
-            }
+        if(this.checkLocationIsValidAndOptionallySetPathStart(i, -1, null) == 0) {
+          //LAB_800e7f88
+          if(directionalPathIndex == this.mapState_800c6798.directionalPathIndex_12) {
+            locationIndex = i;
+            break;
           }
         }
         //LAB_800e7fb4
@@ -5406,14 +5403,12 @@ public class WMap extends EngineState {
     int i;
     for(i = 0; i < this.mapState_800c6798.locationCount_08; i++) {
       //LAB_800ea520
-      if(locations_800f0e34[i].directionalPathIndex_00 != -1) {
-        //LAB_800ea558
-        if(this.checkLocationIsValidAndOptionallySetPathStart(i, 0, null) == 0) {
-          //LAB_800ea578
-          //LAB_800ea5bc
-          if(locations_800f0e34[i].directionalPathIndex_00 == directionalPathIndex) {
-            break;
-          }
+      //LAB_800ea558
+      if(this.checkLocationIsValidAndOptionallySetPathStart(i, 0, null) == 0) {
+        //LAB_800ea578
+        //LAB_800ea5bc
+        if(locations_800f0e34[i].directionalPathIndex_00 == directionalPathIndex) {
+          break;
         }
       }
       //LAB_800ea5f8
@@ -5426,15 +5421,6 @@ public class WMap extends EngineState {
   /** Sets relevant state fields for the path segment the player is either loading into or entering. */
   @Method(0x800ea630L)
   private void setNewPathSegmentStateInfo(final int locationIndex) {
-    if(locations_800f0e34[locationIndex].directionalPathIndex_00 == -1) {
-      return;
-    }
-
-    //LAB_800ea678
-    if(locations_800f0e34[locationIndex].continent_0e != this.mapState_800c6798.continent_00) {
-      return;
-    }
-
     //LAB_800ea6bc
     if(this.checkLocationIsValidAndOptionallySetPathStart(locationIndex, 0, null) != 0) {
       return;

--- a/src/main/java/legend/game/wmap/WMap.java
+++ b/src/main/java/legend/game/wmap/WMap.java
@@ -3260,7 +3260,7 @@ public class WMap extends EngineState {
           //LAB_800e08b8
           this.renderWinglyTeleportScreenEffect();
 
-          this.lerpish(this.wmapStruct258_800c66a8.currPlayerPos_94, originTranslation, targetTranslation, 32.0f / this.wmapStruct258_800c66a8.teleportAnimationTick_24c);
+          this.lerpish(this.wmapStruct258_800c66a8.currPlayerPos_94, originTranslation, targetTranslation, this.wmapStruct258_800c66a8.teleportAnimationTick_24c / (32.0f * (3.0f / vsyncMode_8007a3b8)));
 
           this.wmapStruct258_800c66a8.teleportAnimationTick_24c++;
           if(this.wmapStruct258_800c66a8.teleportAnimationTick_24c / (3.0f / vsyncMode_8007a3b8) > 32) {
@@ -3268,7 +3268,7 @@ public class WMap extends EngineState {
           }
 
           //LAB_800e0980
-          scale = this.wmapStruct258_800c66a8.teleportAnimationTick_24c * 0.015625f + (rsin(this.wmapStruct258_800c66a8.teleportAnimationTick_24c * 0x200) * 0x100 >> 12) / (float)0x1000;
+          scale = (this.wmapStruct258_800c66a8.teleportAnimationTick_24c * 0.015625f) / (3.0f / vsyncMode_8007a3b8) + MathHelper.sin(this.wmapStruct258_800c66a8.teleportAnimationTick_24c * (MathHelper.PI / 4.0f / (3.0f / vsyncMode_8007a3b8))) / 16.0f;
           this.wmapStruct258_800c66a8.models_0c[3].coord2_14.transforms.scale.set(scale, scale, scale);
           this.wmapStruct258_800c66a8.models_0c[this.wmapStruct258_800c66a8.modelIndex_1e4].coord2_14.transforms.rotate.y = this.wmapStruct19c0_800c66b0.mapRotation_70.y;
           this.wmapStruct258_800c66a8.rotation_a4.y = this.wmapStruct19c0_800c66b0.mapRotation_70.y;
@@ -3328,20 +3328,19 @@ public class WMap extends EngineState {
     //LAB_800e0e3c
   }
 
-  /** lerp, but I think it decreases Y more the lower the ratio */
+  /** lerp, but I think it decreases Y more the lower the ratio. Used for teleportation movement. */
   @Method(0x800e0e4cL)
-  private void lerpish(final Vector3f out, final Vector3f a1, final Vector3f a2, final float ratio) {
+  private void lerpish(final Vector3f currPlayerPos, final Vector3f originPos, final Vector3f targetPos, final float ratio) {
     if(ratio == 0.0f) {
-      out.set(a1);
+      currPlayerPos.set(originPos);
     } else if(ratio == 1.0f) {
-      out.set(a2);
+      currPlayerPos.set(targetPos);
     } else {
       //LAB_800e0ed8
-      out.x = a1.x + (a2.x - a1.x) * ratio;
-      out.y = a1.y + (a2.y - a1.y) * ratio + MathHelper.sin(MathHelper.PI * ratio) * -200;
-      out.z = a1.z + (a2.z - a1.z) * ratio;
+      currPlayerPos.x = originPos.x + (targetPos.x - originPos.x) * ratio;
+      currPlayerPos.y = originPos.y + (targetPos.y - originPos.y) * ratio + MathHelper.sin(MathHelper.PI * ratio) * -200;
+      currPlayerPos.z = originPos.z + (targetPos.z - originPos.z) * ratio;
     }
-
     //LAB_800e108c
   }
 

--- a/src/main/java/legend/game/wmap/WMap.java
+++ b/src/main/java/legend/game/wmap/WMap.java
@@ -128,7 +128,7 @@ import static legend.game.wmap.MapState100.PathSegmentEndpointType;
 import static legend.game.wmap.MapState100.ForcedMovementState;
 import static legend.game.wmap.WMapStruct258.FadeState;
 import static legend.game.wmap.WMapStruct258.TransitionAnimationType;
-import static legend.game.wmap.WMapStruct258.MapTransitionAnimationMode;
+import static legend.game.wmap.WMapStruct258.MapTransitionDestinationMode;
 import static legend.game.wmap.WmapStatics.coolonWarpDest_800ef228;
 import static legend.game.wmap.WmapStatics.directionalPathSegmentData_800f2248;
 import static legend.game.wmap.WmapStatics.encounterIds_800ef364;
@@ -484,7 +484,7 @@ public class WMap extends EngineState {
                       if(this.mapState_800c6798.pathSegmentEndpointTypeCrossed_fc != PathSegmentEndpointType.TERMINAL) {
                         if(struct.transitionAnimationType_05 == TransitionAnimationType.NONE) {
                           if(this.mapState_800c6798.queenFuryForceMovementState_d8 == ForcedMovementState.NONE) {
-                            if(struct.mapTransitionAnimationMode_250 == MapTransitionAnimationMode.NO_ANIMATION) {
+                            if(struct.mapTransitionDestinationMode_250 == MapTransitionDestinationMode.NONE) {
                               startFadeEffect(1, 15);
                               this.mapState_800c6798.disableInput_d0 = true;
                               this.tickMainMenuOpenTransition_800c6690 = 1;
@@ -1112,112 +1112,112 @@ public class WMap extends EngineState {
 
     //LAB_800d2ec4
     GsSetRefView2L(struct.rview2_00);
-    this.FUN_800d2fa8();
-    this.FUN_800d3fc8();
+    this.handleMapRotation();
 
     MathHelper.floorMod(struct.mapRotation_70, MathHelper.TWO_PI);
     struct.mapRotationEndAngle_7a = MathHelper.floorMod(struct.mapRotationEndAngle_7a, MathHelper.TWO_PI);
   }
 
   @Method(0x800d2fa8L)
-  private void FUN_800d2fa8() {
-    if(this.wmapStruct258_800c66a8.mapTransitionAnimationMode_250 == MapTransitionAnimationMode.TELEPORT) {
-      return;
-    }
+  private void handleMapRotation() {
+    if(this.wmapStruct258_800c66a8.mapTransitionDestinationMode_250 == MapTransitionDestinationMode.TELEPORT) {
+      //LAB_800d401c
+      this.wmapStruct19c0_800c66b0.mapRotation_70.y += MathHelper.psxDegToRad(8) / (3.0f / vsyncMode_8007a3b8);
+    } else {
+      //LAB_800d2fd4
+      if(this.wmapStruct258_800c66a8.mapTransitionDestinationMode_250 == MapTransitionDestinationMode.SUBMAP && this.wmapStruct258_800c66a8.transitionAnimationType_05 == TransitionAnimationType.NONE) {
+        return;
+      }
 
-    //LAB_800d2fd4
-    if(this.wmapStruct258_800c66a8.mapTransitionAnimationMode_250 == MapTransitionAnimationMode.SUBMAP && this.wmapStruct258_800c66a8.transitionAnimationType_05 == TransitionAnimationType.NONE) {
-      return;
-    }
+      final WMapStruct19c0 struct = this.wmapStruct19c0_800c66b0;
 
-    final WMapStruct19c0 struct = this.wmapStruct19c0_800c66b0;
+      //LAB_800d3014
+      if(struct.mapRotationStep_7c == 0.0f) {
+        struct.mapRotating_80 = false;
+      }
 
-    //LAB_800d3014
-    if(struct.mapRotationStep_7c == 0.0f) {
-      struct.mapRotating_80 = false;
-    }
+      //LAB_800d3040
+      if(struct._110 == 0) {
+        if(this.wmapStruct258_800c66a8.zoomState_1f8 == 0) {
+          if(!struct.hideAtmosphericEffect_c4) {
+            if(this.mapState_800c6798.continent_00 != Continent.ENDINESS) {
+              if(!struct.mapRotating_80) {
+                //LAB_800d30d8
+                if(Input.pressedThisFrame(InputAction.BUTTON_SHOULDER_RIGHT_1)) { // R1
+                  this.startMapRotation(1);
+                  struct.mapRotating_80 = true;
+                }
 
-    //LAB_800d3040
-    if(struct._110 == 0) {
-      if(this.wmapStruct258_800c66a8.zoomState_1f8 == 0) {
-        if(!struct.hideAtmosphericEffect_c4) {
-          if(this.mapState_800c6798.continent_00 != Continent.ENDINESS) {
-            if(!struct.mapRotating_80) {
-              //LAB_800d30d8
-              if(Input.pressedThisFrame(InputAction.BUTTON_SHOULDER_RIGHT_1)) { // R1
-                this.startMapRotation(1);
-                struct.mapRotating_80 = true;
-              }
+                //LAB_800d310c
+                if(Input.pressedThisFrame(InputAction.BUTTON_SHOULDER_LEFT_1)) { // L1
+                  this.startMapRotation(-1);
+                  struct.mapRotating_80 = true;
+                }
 
-              //LAB_800d310c
-              if(Input.pressedThisFrame(InputAction.BUTTON_SHOULDER_LEFT_1)) { // L1
-                this.startMapRotation(-1);
-                struct.mapRotating_80 = true;
-              }
+                //LAB_800d3140
+              } else {
+                //LAB_800d3148
+                struct.mapRotation_70.y += struct.mapRotationStep_7c / (3.0f / vsyncMode_8007a3b8);
+                struct.mapRotationCounter_7e++;
 
-              //LAB_800d3140
-            } else {
-              //LAB_800d3148
-              struct.mapRotation_70.y += struct.mapRotationStep_7c / (3.0f / vsyncMode_8007a3b8);
-              struct.mapRotationCounter_7e++;
-
-              if(struct.mapRotationCounter_7e > 16 / vsyncMode_8007a3b8) {
-                struct.mapRotation_70.y = struct.mapRotationEndAngle_7a;
-                struct.mapRotating_80 = false;
+                if(struct.mapRotationCounter_7e > 16 / vsyncMode_8007a3b8) {
+                  struct.mapRotation_70.y = struct.mapRotationEndAngle_7a;
+                  struct.mapRotating_80 = false;
+                }
               }
             }
           }
         }
       }
-    }
 
-    //LAB_800d31e8
-    this.FUN_800d35fc();
+      //LAB_800d31e8
+      this.FUN_800d35fc();
 
-    final int v0 = this.wmapStruct19c0_800c66b0._110;
-    if(v0 == 1) {
-      //LAB_800d3250
-      this.FUN_800d5018();
-      this.wmapStruct19c0_800c66b0._110 = 2;
-    } else if(v0 == 3) {
-      //LAB_800d3434
+      final int v0 = this.wmapStruct19c0_800c66b0._110;
+      if(v0 == 1) {  // Fade out to submap
+        //LAB_800d3250
+        this.FUN_800d5018();
+        this.wmapStruct19c0_800c66b0._110 = 2;
+      } else if(v0 == 3) {
+        //LAB_800d3434
+        this.wmapStruct19c0_800c66b0.rview2_00.viewpoint_00.y = this.wmapStruct19c0_800c66b0.rview2_c8.viewpoint_00.y + this.wmapStruct19c0_800c66b0.viewpointY_ec * this.wmapStruct19c0_800c66b0._10e;
+        this.wmapStruct19c0_800c66b0.rview2_00.viewpoint_00.z = this.wmapStruct19c0_800c66b0.rview2_c8.viewpoint_00.z + this.wmapStruct19c0_800c66b0.viewpointZ_f0 * this.wmapStruct19c0_800c66b0._10e;
+        this.wmapStruct19c0_800c66b0.rview2_00.refpoint_0c.y = this.wmapStruct19c0_800c66b0.rview2_c8.refpoint_0c.y + this.wmapStruct19c0_800c66b0.refpointY_f8 * this.wmapStruct19c0_800c66b0._10e;
+        this.wmapStruct19c0_800c66b0.rview2_00.refpoint_0c.z = this.wmapStruct19c0_800c66b0.rview2_c8.refpoint_0c.z + this.wmapStruct19c0_800c66b0.refpointZ_fc * this.wmapStruct19c0_800c66b0._10e;
+        this.wmapStruct19c0_800c66b0.mapRotation_70.y = this.wmapStruct19c0_800c66b0.angle_10a + this.wmapStruct19c0_800c66b0.angle_10c * this.wmapStruct19c0_800c66b0._10e;
+
+        if(this.wmapStruct19c0_800c66b0._10e > 0.0f) {
+          this.wmapStruct19c0_800c66b0._10e -= 1.0f / (3.0f / vsyncMode_8007a3b8);
+        } else {
+          this.wmapStruct19c0_800c66b0._110 = 0;
+        }
+
+        return;
+      } else if(v0 < 2) {
+        //LAB_800d3248
+        return;
+      }
+
+      // if == 1 or 2
+
+      //LAB_800d3228
+      //LAB_800d3268
       this.wmapStruct19c0_800c66b0.rview2_00.viewpoint_00.y = this.wmapStruct19c0_800c66b0.rview2_c8.viewpoint_00.y + this.wmapStruct19c0_800c66b0.viewpointY_ec * this.wmapStruct19c0_800c66b0._10e;
       this.wmapStruct19c0_800c66b0.rview2_00.viewpoint_00.z = this.wmapStruct19c0_800c66b0.rview2_c8.viewpoint_00.z + this.wmapStruct19c0_800c66b0.viewpointZ_f0 * this.wmapStruct19c0_800c66b0._10e;
       this.wmapStruct19c0_800c66b0.rview2_00.refpoint_0c.y = this.wmapStruct19c0_800c66b0.rview2_c8.refpoint_0c.y + this.wmapStruct19c0_800c66b0.refpointY_f8 * this.wmapStruct19c0_800c66b0._10e;
       this.wmapStruct19c0_800c66b0.rview2_00.refpoint_0c.z = this.wmapStruct19c0_800c66b0.rview2_c8.refpoint_0c.z + this.wmapStruct19c0_800c66b0.refpointZ_fc * this.wmapStruct19c0_800c66b0._10e;
       this.wmapStruct19c0_800c66b0.mapRotation_70.y = this.wmapStruct19c0_800c66b0.angle_10a + this.wmapStruct19c0_800c66b0.angle_10c * this.wmapStruct19c0_800c66b0._10e;
 
-      if(this.wmapStruct19c0_800c66b0._10e > 0.0f) {
-        this.wmapStruct19c0_800c66b0._10e -= 1.0f / (3.0f / vsyncMode_8007a3b8);
-      } else {
-        this.wmapStruct19c0_800c66b0._110 = 0;
+      this.wmapStruct19c0_800c66b0._10e += 1.0f / (3.0f / vsyncMode_8007a3b8);
+      if(this.wmapStruct19c0_800c66b0._10e >= 16.0f) {
+        this.wmapStruct19c0_800c66b0._10e = 16.0f;
+        this.wmapStruct19c0_800c66b0.mapRotation_70.y = this.wmapStruct19c0_800c66b0.angle_108;
       }
 
-      return;
-    } else if(v0 < 2) {
-      //LAB_800d3248
-      return;
+      //LAB_800d342c
+      //LAB_800d35e4
+      //LAB_800d35ec
     }
-
-    // if == 1 or 2
-
-    //LAB_800d3228
-    //LAB_800d3268
-    this.wmapStruct19c0_800c66b0.rview2_00.viewpoint_00.y = this.wmapStruct19c0_800c66b0.rview2_c8.viewpoint_00.y + this.wmapStruct19c0_800c66b0.viewpointY_ec * this.wmapStruct19c0_800c66b0._10e;
-    this.wmapStruct19c0_800c66b0.rview2_00.viewpoint_00.z = this.wmapStruct19c0_800c66b0.rview2_c8.viewpoint_00.z + this.wmapStruct19c0_800c66b0.viewpointZ_f0 * this.wmapStruct19c0_800c66b0._10e;
-    this.wmapStruct19c0_800c66b0.rview2_00.refpoint_0c.y = this.wmapStruct19c0_800c66b0.rview2_c8.refpoint_0c.y + this.wmapStruct19c0_800c66b0.refpointY_f8 * this.wmapStruct19c0_800c66b0._10e;
-    this.wmapStruct19c0_800c66b0.rview2_00.refpoint_0c.z = this.wmapStruct19c0_800c66b0.rview2_c8.refpoint_0c.z + this.wmapStruct19c0_800c66b0.refpointZ_fc * this.wmapStruct19c0_800c66b0._10e;
-    this.wmapStruct19c0_800c66b0.mapRotation_70.y = this.wmapStruct19c0_800c66b0.angle_10a + this.wmapStruct19c0_800c66b0.angle_10c * this.wmapStruct19c0_800c66b0._10e;
-
-    this.wmapStruct19c0_800c66b0._10e += 1.0f / (3.0f / vsyncMode_8007a3b8);
-    if(this.wmapStruct19c0_800c66b0._10e >= 16.0f) {
-      this.wmapStruct19c0_800c66b0._10e = 16.0f;
-      this.wmapStruct19c0_800c66b0.mapRotation_70.y = this.wmapStruct19c0_800c66b0.angle_108;
-    }
-
-    //LAB_800d342c
-    //LAB_800d35e4
-    //LAB_800d35ec
   }
 
   // TODO something to do with camera movement
@@ -1346,14 +1346,6 @@ public class WMap extends EngineState {
     //LAB_800d3fa4
     //LAB_800d3fac
     this.renderPlayerAndDestinationIndicators();
-  }
-
-  @Method(0x800d3fc8L)
-  private void FUN_800d3fc8() {
-    if(this.wmapStruct258_800c66a8.mapTransitionAnimationMode_250 == MapTransitionAnimationMode.TELEPORT) {
-      //LAB_800d401c
-      this.wmapStruct19c0_800c66b0.mapRotation_70.y += MathHelper.psxDegToRad(8) / (3.0f / vsyncMode_8007a3b8);
-    }
   }
 
   @Method(0x800d4058L)
@@ -1963,7 +1955,7 @@ public class WMap extends EngineState {
     }
 
     //LAB_800d692c
-    if(this.wmapStruct258_800c66a8.mapTransitionAnimationMode_250 == MapTransitionAnimationMode.SUBMAP) {
+    if(this.wmapStruct258_800c66a8.mapTransitionDestinationMode_250 == MapTransitionDestinationMode.SUBMAP) {
       return;
     }
 
@@ -2339,7 +2331,7 @@ public class WMap extends EngineState {
     }
 
     //LAB_800d951c
-    if(this.wmapStruct258_800c66a8.mapTransitionAnimationMode_250 != MapTransitionAnimationMode.NO_ANIMATION) {
+    if(this.wmapStruct258_800c66a8.mapTransitionDestinationMode_250 != MapTransitionDestinationMode.NONE) {
       return;
     }
 
@@ -2546,7 +2538,7 @@ public class WMap extends EngineState {
     }
 
     //LAB_800da420
-    if(struct.mapTransitionAnimationMode_250 == MapTransitionAnimationMode.TELEPORT) {
+    if(struct.mapTransitionDestinationMode_250 == MapTransitionDestinationMode.TELEPORT) {
       return;
     }
 
@@ -2562,11 +2554,11 @@ public class WMap extends EngineState {
     if(Input.pressedThisFrame(InputAction.BUTTON_WEST)) { // Square
       this.destinationLabelStage_800c86f0 = 0;
       this.shouldSetCoolonWarpDestLabelMetrics = true;
-      struct.mapTransitionAnimationMode_250 = MapTransitionAnimationMode.SUBMAP;
+      struct.mapTransitionDestinationMode_250 = MapTransitionDestinationMode.SUBMAP;
     }
 
     //LAB_800da520
-    if(struct.mapTransitionAnimationMode_250 != MapTransitionAnimationMode.SUBMAP) {
+    if(struct.mapTransitionDestinationMode_250 != MapTransitionDestinationMode.SUBMAP) {
       return;
     }
 
@@ -2831,7 +2823,7 @@ public class WMap extends EngineState {
           this.mapState_800c6798.submapScene_ca = locations_800f0e34[coolonWarpDest_800ef228[struct.coolonWarpIndex_222].locationIndex_10].submapScene_06;
           submapCut_80052c30.set(this.mapState_800c6798.submapCut_c8);
           index_80052c38.set(this.mapState_800c6798.submapScene_ca);
-          struct.mapTransitionAnimationMode_250 = MapTransitionAnimationMode.WORLD_MAP;
+          struct.mapTransitionDestinationMode_250 = MapTransitionDestinationMode.WORLD_MAP;
           previousEngineState_8004dd28 = null;
         }
 
@@ -2922,7 +2914,7 @@ public class WMap extends EngineState {
 
         this.wmapStruct19c0_800c66b0.mapRotation_70.y = struct.angle_21e;
 
-        struct.mapTransitionAnimationMode_250 = MapTransitionAnimationMode.NO_ANIMATION;
+        struct.mapTransitionDestinationMode_250 = MapTransitionDestinationMode.NONE;
         struct._220 = 0;
         return;
     }
@@ -3170,7 +3162,7 @@ public class WMap extends EngineState {
   private void renderPlayer() {
     final WMapStruct258 struct = this.wmapStruct258_800c66a8;
 
-    if(struct.mapTransitionAnimationMode_250 != MapTransitionAnimationMode.SUBMAP) {
+    if(struct.mapTransitionDestinationMode_250 != MapTransitionDestinationMode.SUBMAP) {
       struct.modelIndex_1e4 = directionalPathSegmentData_800f2248.get(this.mapState_800c6798.directionalPathIndex_12).modelIndex_06.get();
 
       assert struct.modelIndex_1e4 < 4;
@@ -3234,10 +3226,10 @@ public class WMap extends EngineState {
   private void FUN_800e06d0() {
     this.wmapStruct258_800c66a8.prevPlayerPos_84.set(this.wmapStruct258_800c66a8.currPlayerPos_94);
 
-    if(this.wmapStruct258_800c66a8.mapTransitionAnimationMode_250 == MapTransitionAnimationMode.NO_ANIMATION) {
+    if(this.wmapStruct258_800c66a8.mapTransitionDestinationMode_250 == MapTransitionDestinationMode.NONE) {
       //LAB_800e0760
       this.FUN_800e8a10();
-    } else if(this.wmapStruct258_800c66a8.mapTransitionAnimationMode_250 == MapTransitionAnimationMode.TELEPORT) {
+    } else if(this.wmapStruct258_800c66a8.mapTransitionDestinationMode_250 == MapTransitionDestinationMode.TELEPORT) {
       //LAB_800e0770
       //LAB_800e0774
       int locationIndex = 0;
@@ -3406,7 +3398,7 @@ public class WMap extends EngineState {
     struct.coord2_34.coord.transfer.set(struct.currPlayerPos_94);
     struct.models_0c[struct.modelIndex_1e4].coord2_14.coord.transfer.set(struct.coord2_34.coord.transfer);
 
-    if(struct.mapTransitionAnimationMode_250 == MapTransitionAnimationMode.NO_ANIMATION) {
+    if(struct.mapTransitionDestinationMode_250 == MapTransitionDestinationMode.NONE) {
       float sp10 = struct.rotation_a4.y - struct.models_0c[struct.modelIndex_1e4].coord2_14.transforms.rotate.y;
       final float sp14 = struct.rotation_a4.y - (struct.models_0c[struct.modelIndex_1e4].coord2_14.transforms.rotate.y - MathHelper.TWO_PI);
 
@@ -3815,7 +3807,7 @@ public class WMap extends EngineState {
   @Method(0x800e406cL)
   private void tickFadeInTransition() {
     final WMapStruct258 struct = this.wmapStruct258_800c66a8;
-    if(struct.mapTransitionAnimationMode_250 == MapTransitionAnimationMode.TELEPORT) {
+    if(struct.mapTransitionDestinationMode_250 == MapTransitionDestinationMode.TELEPORT) {
       //LAB_800e442c
       switch(struct.fadeState_04) {
         case START_FADE:
@@ -3868,8 +3860,8 @@ public class WMap extends EngineState {
           break;
       }
     } else if(
-      struct.mapTransitionAnimationMode_250 == MapTransitionAnimationMode.NO_ANIMATION ||
-        struct.mapTransitionAnimationMode_250 == MapTransitionAnimationMode.SUBMAP
+      struct.mapTransitionDestinationMode_250 == MapTransitionDestinationMode.NONE ||
+        struct.mapTransitionDestinationMode_250 == MapTransitionDestinationMode.SUBMAP
     ) {
       switch(struct.fadeState_04) {
         case START_FADE:
@@ -3987,10 +3979,10 @@ public class WMap extends EngineState {
             }
 
             //LAB_800e48c4
-            if(struct.mapTransitionAnimationMode_250 == MapTransitionAnimationMode.SUBMAP) {
+            if(struct.mapTransitionDestinationMode_250 == MapTransitionDestinationMode.SUBMAP) {
               this.wmapState_800bb10c = WmapState.TRANSITION_TO_SUBMAP_7;
               //LAB_800e48f4
-            } else if(struct.mapTransitionAnimationMode_250 == MapTransitionAnimationMode.WORLD_MAP) {
+            } else if(struct.mapTransitionDestinationMode_250 == MapTransitionDestinationMode.WORLD_MAP) {
               this.wmapState_800bb10c = WmapState.TRANSITION_TO_WORLD_MAP_9;
             }
           }
@@ -4864,7 +4856,7 @@ public class WMap extends EngineState {
     }
 
     //LAB_800e8720
-    this.wmapStruct258_800c66a8.mapTransitionAnimationMode_250 = MapTransitionAnimationMode.NO_ANIMATION;
+    this.wmapStruct258_800c66a8.mapTransitionDestinationMode_250 = MapTransitionDestinationMode.NONE;
     this.wmapStruct258_800c66a8.usingCoolonFromZenebatos_254 = false;
 
     //LAB_800e8770
@@ -4880,12 +4872,12 @@ public class WMap extends EngineState {
         this.mapState_800c6798.submapCut_c4 == 572 && this.mapState_800c6798.submapScene_c6 == 23     // Aglis to Zenebatos
     ) {
       //LAB_800e8830
-      this.wmapStruct258_800c66a8.mapTransitionAnimationMode_250 = MapTransitionAnimationMode.TELEPORT;
+      this.wmapStruct258_800c66a8.mapTransitionDestinationMode_250 = MapTransitionDestinationMode.TELEPORT;
       //LAB_800e8848
 
       // Zenebatos to Coolon map
     } else if(this.mapState_800c6798.submapCut_c4 == 529 && this.mapState_800c6798.submapScene_c6 == 41) {
-      this.wmapStruct258_800c66a8.mapTransitionAnimationMode_250 = MapTransitionAnimationMode.SUBMAP;
+      this.wmapStruct258_800c66a8.mapTransitionDestinationMode_250 = MapTransitionDestinationMode.SUBMAP;
       this.wmapStruct258_800c66a8.usingCoolonFromZenebatos_254 = true;
       gameState_800babc8.visitedLocations_17c.set(this.mapState_800c6798.locationIndex_10, true);
     }

--- a/src/main/java/legend/game/wmap/WMap.java
+++ b/src/main/java/legend/game/wmap/WMap.java
@@ -2369,9 +2369,9 @@ public class WMap extends EngineState {
         //LAB_800d96b8
         this.FUN_800d9eb0();
 
-        this.wmapStruct258_800c66a8._1f9++;
+        this.wmapStruct258_800c66a8.zoomAnimationTick_1f9++;
 
-        if(this.wmapStruct258_800c66a8._1f9 >= 18 / vsyncMode_8007a3b8) {
+        if(this.wmapStruct258_800c66a8.zoomAnimationTick_1f9 >= 18 / vsyncMode_8007a3b8) {
           this.wmapStruct19c0_800c66b0.coord2_20.coord.transfer.set(mapPositions_800ef1a8[this.mapState_800c6798.continent_00.ordinal()]);
           this.wmapStruct258_800c66a8.zoomState_1f8 = 3;
 
@@ -2444,9 +2444,9 @@ public class WMap extends EngineState {
         //LAB_800d9b18
         this.FUN_800d9eb0();
 
-        this.wmapStruct258_800c66a8._1f9++;
+        this.wmapStruct258_800c66a8.zoomAnimationTick_1f9++;
 
-        if(this.wmapStruct258_800c66a8._1f9 >= 18 / vsyncMode_8007a3b8) {
+        if(this.wmapStruct258_800c66a8.zoomAnimationTick_1f9 >= 18 / vsyncMode_8007a3b8) {
           this.wmapStruct19c0_800c66b0.coord2_20.coord.transfer.set(this.wmapStruct258_800c66a8.svec_1e8);
           this.wmapStruct258_800c66a8.mapArrow.setSize(16.0f);
           this.wmapStruct258_800c66a8.zoomState_1f8 = 6;
@@ -2474,7 +2474,7 @@ public class WMap extends EngineState {
     wmap.svec_1f0.x = (vec.x - wmap.svec_1e8.x) * zoomDirection / 6.0f / (3.0f / vsyncMode_8007a3b8);
     wmap.svec_1f0.y = (vec.y - wmap.svec_1e8.y) * zoomDirection / 6.0f / (3.0f / vsyncMode_8007a3b8);
     wmap.svec_1f0.z = (vec.z - wmap.svec_1e8.z) * zoomDirection / 6.0f / (3.0f / vsyncMode_8007a3b8);
-    wmap._1f9 = 0;
+    wmap.zoomAnimationTick_1f9 = 0;
   }
 
   @Method(0x800d9eb0L)

--- a/src/main/java/legend/game/wmap/WMap.java
+++ b/src/main/java/legend/game/wmap/WMap.java
@@ -3263,12 +3263,12 @@ public class WMap extends EngineState {
           this.lerpish(this.wmapStruct258_800c66a8.currPlayerPos_94, originTranslation, targetTranslation, 32.0f / this.wmapStruct258_800c66a8.teleportAnimationTick_24c);
 
           this.wmapStruct258_800c66a8.teleportAnimationTick_24c++;
-          if(this.wmapStruct258_800c66a8.teleportAnimationTick_24c > 32) {
+          if(this.wmapStruct258_800c66a8.teleportAnimationTick_24c / (3.0f / vsyncMode_8007a3b8) > 32) {
             this.wmapStruct258_800c66a8.teleportAnimationState_248 = TeleportAnimationState.INIT_FADE;
           }
 
           //LAB_800e0980
-          scale = this.wmapStruct258_800c66a8.teleportAnimationTick_24c * 0x40 + (rsin(this.wmapStruct258_800c66a8.teleportAnimationTick_24c * 0x200) * 0x100 >> 12) / (float)0x1000;
+          scale = this.wmapStruct258_800c66a8.teleportAnimationTick_24c * 0.015625f + (rsin(this.wmapStruct258_800c66a8.teleportAnimationTick_24c * 0x200) * 0x100 >> 12) / (float)0x1000;
           this.wmapStruct258_800c66a8.models_0c[3].coord2_14.transforms.scale.set(scale, scale, scale);
           this.wmapStruct258_800c66a8.models_0c[this.wmapStruct258_800c66a8.modelIndex_1e4].coord2_14.transforms.rotate.y = this.wmapStruct19c0_800c66b0.mapRotation_70.y;
           this.wmapStruct258_800c66a8.rotation_a4.y = this.wmapStruct19c0_800c66b0.mapRotation_70.y;

--- a/src/main/java/legend/game/wmap/WMap.java
+++ b/src/main/java/legend/game/wmap/WMap.java
@@ -125,6 +125,7 @@ import static legend.game.Scus94491BpeSegment_800c.lightColourMatrix_800c3508;
 import static legend.game.Scus94491BpeSegment_800c.lightDirectionMatrix_800c34e8;
 import static legend.game.wmap.MapState100.PathSegmentEntering;
 import static legend.game.wmap.MapState100.PathSegmentEndpointType;
+import static legend.game.wmap.MapState100.ForcedMovementState;
 import static legend.game.wmap.WMapStruct258.FadeState;
 import static legend.game.wmap.WMapStruct258.TransitionAnimationType;
 import static legend.game.wmap.WMapStruct258.MapTransitionAnimationMode;
@@ -482,7 +483,7 @@ public class WMap extends EngineState {
                     if(Input.pressedThisFrame(InputAction.BUTTON_NORTH)) {
                       if(this.mapState_800c6798.pathSegmentEndpointTypeCrossed_fc != PathSegmentEndpointType.TERMINAL) {
                         if(struct.transitionAnimationType_05 == TransitionAnimationType.NONE) {
-                          if(this.mapState_800c6798._d8 == 0) {
+                          if(this.mapState_800c6798.queenFuryForceMovementState_d8 == ForcedMovementState.NONE) {
                             if(struct.mapTransitionAnimationMode_250 == MapTransitionAnimationMode.NO_ANIMATION) {
                               startFadeEffect(1, 15);
                               this.mapState_800c6798.disableInput_d0 = true;
@@ -727,7 +728,7 @@ public class WMap extends EngineState {
     zOffset_1f8003e8.set(0);
     tmdGp0Tpage_1f8003ec.set(0x20);
 
-    this.initTransitionAnimation(TransitionAnimationType.NONE);
+    this.initTransitionAnimation(TransitionAnimationType.FADE_IN);
     this.FUN_800e78c0();
     this.loadWmapTextures();
     this.initCameraAndLight();
@@ -1227,7 +1228,11 @@ public class WMap extends EngineState {
       //LAB_800d3654
       //LAB_800d3670
       //LAB_800d368c
-      if(this.mapState_800c6798.continent_00 != Continent.ENDINESS && this.mapState_800c6798._d8 == 0 && this.tickMainMenuOpenTransition_800c6690 == 0) {
+      if(
+        this.mapState_800c6798.continent_00 != Continent.ENDINESS &&
+          this.mapState_800c6798.queenFuryForceMovementState_d8 == ForcedMovementState.NONE &&
+          this.tickMainMenuOpenTransition_800c6690 == 0
+      ) {
         //LAB_800d36a8
         if(this.mapState_800c6798.pathSegmentEndpointTypeCrossed_fc != PathSegmentEndpointType.TERMINAL) {
           if(!this.wmapStruct19c0_800c66b0.mapRotating_80) {
@@ -1993,7 +1998,7 @@ public class WMap extends EngineState {
     }
 
     //LAB_800d6b80
-    if(this.mapState_800c6798._d8 != 0) {
+    if(this.mapState_800c6798.queenFuryForceMovementState_d8 != ForcedMovementState.NONE) {
       return;
     }
 
@@ -2530,8 +2535,9 @@ public class WMap extends EngineState {
     }
 
     //LAB_800da360
+    // Show square prompt while sailing Queen Fury
     if(struct.modelIndex_1e4 == 1) {
-      if(gameState_800babc8.scriptFlags2_bc.get(0x97) && this.mapState_800c6798._d8 == 0) {
+      if(gameState_800babc8.scriptFlags2_bc.get(0x97) && this.mapState_800c6798.queenFuryForceMovementState_d8 == ForcedMovementState.NONE) {
         this.coolonQueenFuryOverlay.render(1);
       }
 
@@ -2705,7 +2711,7 @@ public class WMap extends EngineState {
             submapCut_80052c30.set(this.mapState_800c6798.submapCut_c8);
             submapScene_80052c34.set(this.mapState_800c6798.submapScene_ca);
 
-            this.initTransitionAnimation(TransitionAnimationType.FADE_IN);
+            this.initTransitionAnimation(TransitionAnimationType.FADE_OUT);
           } else {
             //LAB_800daff4
             struct._220 = 10;
@@ -2831,7 +2837,7 @@ public class WMap extends EngineState {
 
         //LAB_800dba98
 
-        this.initTransitionAnimation(TransitionAnimationType.FADE_IN);
+        this.initTransitionAnimation(TransitionAnimationType.FADE_OUT);
         this.renderCoolonMap(false, true);
         break;
 
@@ -3282,7 +3288,7 @@ public class WMap extends EngineState {
         submapCut_80052c30.set(this.mapState_800c6798.submapCut_c8);
         submapScene_80052c34.set(this.mapState_800c6798.submapScene_ca);
 
-        this.initTransitionAnimation(TransitionAnimationType.FADE_IN);
+        this.initTransitionAnimation(TransitionAnimationType.FADE_OUT);
         this.wmapStruct258_800c66a8._248 = 3;
       } else if(this.wmapStruct258_800c66a8._248 == 3) {
         //LAB_800e0c00
@@ -3669,7 +3675,10 @@ public class WMap extends EngineState {
     }
 
     //LAB_800e3748
-    if(this.mapState_800c6798._d4 != 0 || this.mapState_800c6798._d8 != 0) {
+    if(
+      this.mapState_800c6798.shortForceMovementState_d4 != ForcedMovementState.NONE ||
+      this.mapState_800c6798.queenFuryForceMovementState_d8 != ForcedMovementState.NONE
+    ) {
       //LAB_800e3778
       return;
     }
@@ -3846,12 +3855,12 @@ public class WMap extends EngineState {
             struct.transitionAnimationTicks_00++;
 
             if(struct.transitionAnimationTicks_00 >= 6 / vsyncMode_8007a3b8) {
-              this.mapState_800c6798._d4 = 0;
+              this.mapState_800c6798.shortForceMovementState_d4 = ForcedMovementState.NONE;
             }
           }
 
           //LAB_800e4624
-          if(this.wmapStruct19c0_800c66b0._c5 == 0 && this.mapState_800c6798._d4 == 0) {
+          if(this.wmapStruct19c0_800c66b0._c5 == 0 && this.mapState_800c6798.shortForceMovementState_d4 == ForcedMovementState.NONE) {
             this.mapState_800c6798.disableInput_d0 = false;
             struct.transitionAnimationType_05 = TransitionAnimationType.NONE;
           }
@@ -3905,12 +3914,12 @@ public class WMap extends EngineState {
             struct.transitionAnimationTicks_00++;
 
             if(struct.transitionAnimationTicks_00 >= 6 / vsyncMode_8007a3b8) {
-              this.mapState_800c6798._d4 = 0;
+              this.mapState_800c6798.shortForceMovementState_d4 = ForcedMovementState.NONE;
             }
           }
 
           //LAB_800e43c4
-          if(this.wmapStruct19c0_800c66b0._c5 == 0 && this.mapState_800c6798._d4 == 0) {
+          if(this.wmapStruct19c0_800c66b0._c5 == 0 && this.mapState_800c6798.shortForceMovementState_d4 == ForcedMovementState.NONE) {
             this.mapState_800c6798.disableInput_d0 = false;
             struct.transitionAnimationType_05 = TransitionAnimationType.NONE;
           }
@@ -4285,7 +4294,7 @@ public class WMap extends EngineState {
             //LAB_800e6404
           } else {
             //LAB_800e640c
-            this.initTransitionAnimation(TransitionAnimationType.FADE_IN);
+            this.initTransitionAnimation(TransitionAnimationType.FADE_OUT);
             FUN_8002a3ec(6, 0);
             FUN_8002a3ec(7, 1);
             this.mapTransitionState_800c68a4 = 5;
@@ -4343,6 +4352,7 @@ public class WMap extends EngineState {
         //LAB_800e66cc
         break;
 
+      // Backing out of location entrance prompt, set up for forced movement
       case 6:
         this.wmapLocationPromptPopup.deallocate();
 
@@ -4356,7 +4366,7 @@ public class WMap extends EngineState {
         }
 
         //LAB_800e671c
-        this.mapState_800c6798._d4 = 1;
+        this.mapState_800c6798.shortForceMovementState_d4 = ForcedMovementState.WALK;
         this.cancelLocationEntryDelayTick_800c68a0 = 0;
         this.mapTransitionState_800c68a4 = 7;
 
@@ -4373,7 +4383,7 @@ public class WMap extends EngineState {
       case 8:
         this.mapTransitionState_800c68a4 = 0;
         this.mapState_800c6798.disableInput_d0 = false;
-        this.mapState_800c6798._d4 = 0;
+        this.mapState_800c6798.shortForceMovementState_d4 = ForcedMovementState.NONE;
         this.mapState_800c6798.pathSegmentEndpointTypeCrossed_fc = PathSegmentEndpointType.NOT_AT_ENDPOINT;
         this.startLocationLabelsActive_800c68a8 = true;
 
@@ -4730,7 +4740,7 @@ public class WMap extends EngineState {
 
     this.FUN_800ea630(locationIndex);
 
-    this.mapState_800c6798._d8 = 0;
+    this.mapState_800c6798.queenFuryForceMovementState_d8 = ForcedMovementState.NONE;
 
     boolean transitionFromCombatOrShip = previousEngineState_8004dd28 == EngineStateEnum.COMBAT_06 && this.mapState_800c6798.submapCut_c4 != 999;
 
@@ -4744,7 +4754,7 @@ public class WMap extends EngineState {
     if(!transitionFromCombatOrShip && !loadingNewGameState_800bdc34.get() || reinitializingWmap_80052c6c) {
       //LAB_800e844c
       // Transition from submap or other world map
-      this.mapState_800c6798._d4 = 1;
+      this.mapState_800c6798.shortForceMovementState_d4 = ForcedMovementState.WALK;
       this.mapState_800c6798.disableInput_d0 = true;
     } else {
       // Transition from title or combat to world map (or sailing Queen Fury)
@@ -4753,7 +4763,7 @@ public class WMap extends EngineState {
       this.mapState_800c6798.dotIndex_16 = gameState_800babc8.dotIndex_4da;
       this.mapState_800c6798.dotOffset_18 = gameState_800babc8.dotOffset_4dc;
       this.mapState_800c6798.facing_1c = gameState_800babc8.facing_4dd;
-      this.mapState_800c6798._d4 = 0;
+      this.mapState_800c6798.shortForceMovementState_d4 = ForcedMovementState.NONE;
       this.mapState_800c6798.disableInput_d0 = false;
 
       //LAB_800e7f00
@@ -4835,17 +4845,19 @@ public class WMap extends EngineState {
     this.wmapStruct258_800c66a8.coord2_34.coord.transfer.y -= 2.0f;
 
     if(this.mapState_800c6798.submapCut_c4 == 242 && this.mapState_800c6798.submapScene_c6 == 3) { // Donau
+      // First time Queen Fury leaves Donau, with forced movement
       if(gameState_800babc8.scriptFlags2_bc.get(0x8f)) {
-        this.mapState_800c6798._d4 = 0;
-        this.mapState_800c6798._d8 = 1;
+        this.mapState_800c6798.shortForceMovementState_d4 = ForcedMovementState.NONE;
+        this.mapState_800c6798.queenFuryForceMovementState_d8 = ForcedMovementState.WALK;
         this.mapState_800c6798.disableInput_d0 = true;
       }
 
       //LAB_800e8684
+      // Queen Fury leaving Donau after first time
       if(gameState_800babc8.scriptFlags2_bc.get(0x90)) {
         this.mapState_800c6798.disableInput_d0 = true;
-        this.mapState_800c6798._d4 = 1;
-        this.mapState_800c6798._d8 = 0;
+        this.mapState_800c6798.shortForceMovementState_d4 = ForcedMovementState.WALK;
+        this.mapState_800c6798.queenFuryForceMovementState_d8 = ForcedMovementState.NONE;
       }
     }
 
@@ -4907,7 +4919,7 @@ public class WMap extends EngineState {
 
   @Method(0x800e8a90L)
   private void FUN_800e8a90() {
-    if(this.mapState_800c6798._d8 != 0) {
+    if(this.mapState_800c6798.queenFuryForceMovementState_d8 != ForcedMovementState.NONE) {
       this.mapState_800c6798.disableInput_d0 = true;
 
       if(this.wmapStruct258_800c66a8.transitionAnimationType_05 != TransitionAnimationType.NONE) {
@@ -4917,7 +4929,7 @@ public class WMap extends EngineState {
       //LAB_800e8ae0
     } else {
       //LAB_800e8ae8
-      if(this.mapState_800c6798._d4 == 0) {
+      if(this.mapState_800c6798.shortForceMovementState_d4 == ForcedMovementState.NONE) {
         return;
       }
 
@@ -4953,7 +4965,11 @@ public class WMap extends EngineState {
     }
 
     //LAB_800e8bfc
-    if(this.mapState_800c6798._d4 == 2 || this.mapState_800c6798._d8 == 2) {
+    // These values never actually set to RUN, but who knows, maybe someone will want it.
+    if(
+      this.mapState_800c6798.shortForceMovementState_d4 == ForcedMovementState.RUN ||
+        this.mapState_800c6798.queenFuryForceMovementState_d8 == ForcedMovementState.RUN
+    ) {
       //LAB_800e8c2c
       movement *= 2;
     }
@@ -5027,7 +5043,7 @@ public class WMap extends EngineState {
       //LAB_800e8f24
       if(this.wmapStruct258_800c66a8.modelIndex_1e4 == 1) {
         //LAB_800e8f48
-        if(this.mapState_800c6798._d8 == 0) {
+        if(this.mapState_800c6798.queenFuryForceMovementState_d8 == ForcedMovementState.NONE) {
           //LAB_800e8f64
           //LAB_800e8f88
           if(this.wmapStruct258_800c66a8.transitionAnimationType_05 == TransitionAnimationType.NONE) {
@@ -5050,7 +5066,7 @@ public class WMap extends EngineState {
                             this.mapState_800c6798.submapScene_ca = locations_800f0e34[93].submapScene_0a;
                             submapCut_80052c30.set(this.mapState_800c6798.submapCut_c8);
                             submapScene_80052c34.set(this.mapState_800c6798.submapScene_ca);
-                            this.initTransitionAnimation(TransitionAnimationType.FADE_IN);
+                            this.initTransitionAnimation(TransitionAnimationType.FADE_OUT);
                           }
                         }
                       }
@@ -5090,7 +5106,7 @@ public class WMap extends EngineState {
     }
 
     //LAB_800e91b0
-    if(this.mapState_800c6798._d8 != 0) {
+    if(this.mapState_800c6798.queenFuryForceMovementState_d8 != ForcedMovementState.NONE) {
       return;
     }
 
@@ -5264,12 +5280,13 @@ public class WMap extends EngineState {
     int currentMovementToPathAngle = 0x1000;
 
     //LAB_800e9da0
-    if(this.mapState_800c6798._d8 != 0) {
-      if(this.mapState_800c6798._d8 < 3) {
-        this.initTransitionAnimation(TransitionAnimationType.FADE_IN);
+    // Transition to Queen Fury deck for Shana scene
+    if(this.mapState_800c6798.queenFuryForceMovementState_d8 != ForcedMovementState.NONE) {
+      if(this.mapState_800c6798.queenFuryForceMovementState_d8.ordinal() < ForcedMovementState.FADE_OUT.ordinal()) {
+        this.initTransitionAnimation(TransitionAnimationType.FADE_OUT);
         submapCut_80052c30.set(285); // A Queen Fury cut
         submapScene_80052c34.set(32);
-        this.mapState_800c6798._d8 = 3;
+        this.mapState_800c6798.queenFuryForceMovementState_d8 = ForcedMovementState.FADE_OUT;
       }
 
       //LAB_800e9dfc

--- a/src/main/java/legend/game/wmap/WMap.java
+++ b/src/main/java/legend/game/wmap/WMap.java
@@ -978,7 +978,7 @@ public class WMap extends EngineState {
       //LAB_800d1e38
       if(!places_800f0234.get(locations_800f0e34[i].placeIndex_02).name_00.isNull()) {
         //LAB_800d1e90
-        if(this.FUN_800eb09c(i, 1, this.wmapStruct19c0_800c66b0._154[count].position_08) == 0) {
+        if(this.checkLocationIsValidAndOptionallySetPathStart(i, 1, this.wmapStruct19c0_800c66b0._154[count].position_08) == 0) {
           //LAB_800d1ee0
           final float dx = x - this.wmapStruct19c0_800c66b0._154[count].position_08.x;
           final float dy = y - this.wmapStruct19c0_800c66b0._154[count].position_08.y;
@@ -2120,7 +2120,7 @@ public class WMap extends EngineState {
     //LAB_800d7d6c
     for(int i = 0; i < this.mapState_800c6798.locationCount_08; i++) {
       //LAB_800d7d90
-      if(this.FUN_800eb09c(i, 1, intersectionPoint) == 0) {
+      if(this.checkLocationIsValidAndOptionallySetPathStart(i, 1, intersectionPoint) == 0) {
         //LAB_800d7db4
         if(this.mapState_800c6798.continent_00 != Continent.ENDINESS || i == 31 || i == 78) {
           transforms.set(lw)
@@ -2153,7 +2153,7 @@ public class WMap extends EngineState {
     //LAB_800d8540
     for(int i = 0; i < this.mapState_800c6798.locationCount_08; i++) {
       //LAB_800d8564
-      if(this.FUN_800eb09c(i, 0, null) == 0) {
+      if(this.checkLocationIsValidAndOptionallySetPathStart(i, 0, null) == 0) {
         //LAB_800d8584
         if(this.mapState_800c6798.continent_00 != Continent.ENDINESS || i == 31 || i == 78) {
           //LAB_800d85c0
@@ -4065,11 +4065,11 @@ public class WMap extends EngineState {
         }
 
         //LAB_800e533c
-        this.FUN_800ea4dc(pathIndex);
+        this.identifyNewPathSegmentAndSetStateInfo(pathIndex);
 
         this.mapState_800c6798.facing_1c = -this.mapState_800c6798.facing_1c;
 
-        this.FUN_800eab94(this.mapState_800c6798.locationIndex_10);
+        this.initDataForReversePath(this.mapState_800c6798.locationIndex_10);
 
         this.mapState_800c6798.disableInput_d0 = true;
         this.mapState_800c6798.pathSegmentEndpointTypeCrossed_fc = PathSegmentEndpointType.TERMINAL;
@@ -4647,6 +4647,7 @@ public class WMap extends EngineState {
   private void FUN_800e78c0() {
     //LAB_800e7940
     //LAB_800e7944
+    // Set all destination flags in the gameState
     for(int i = 0; i < 49; i++) {
       //LAB_800e7984
       if(gameState_800babc8.scriptFlags2_bc.get(wmapDestinationMarkers_800f5a6c.get(i).packedFlag_00.get())) {
@@ -4664,6 +4665,7 @@ public class WMap extends EngineState {
     this.mapState_800c6798.submapCut_c4 = submapCut_80052c30.get();
     this.mapState_800c6798.submapScene_c6 = index_80052c38.get();
 
+    // If Debug Room Floor 1
     if(this.mapState_800c6798.submapCut_c4 == 0 && this.mapState_800c6798.submapScene_c6 == 0) {
       this.mapState_800c6798.submapCut_c4 = 13; // Hellena
       this.mapState_800c6798.submapScene_c6 = 17;
@@ -4671,12 +4673,15 @@ public class WMap extends EngineState {
 
     //LAB_800e7b44
     //LAB_800e7b54
-    boolean sp18 = false;
+    boolean locationFound = false;
     int locationIndex;
     for(locationIndex = 0; locationIndex < 0x100; locationIndex++) {
       //LAB_800e7b70
-      if(locations_800f0e34[locationIndex].submapCut_04 == this.mapState_800c6798.submapCut_c4 && locations_800f0e34[locationIndex].submapScene_06 == this.mapState_800c6798.submapScene_c6) {
-        sp18 = true;
+      if(
+        locations_800f0e34[locationIndex].submapCut_04 == this.mapState_800c6798.submapCut_c4 &&
+          locations_800f0e34[locationIndex].submapScene_06 == this.mapState_800c6798.submapScene_c6
+      ) {
+        locationFound = true;
         break;
       }
       //LAB_800e7bc0
@@ -4684,7 +4689,7 @@ public class WMap extends EngineState {
 
     //LAB_800e7be8
     //LAB_800e7c18
-    if(!sp18 || !gameState_800babc8.wmapFlags_15c.get(locationIndex)) {
+    if(!locationFound || !gameState_800babc8.wmapFlags_15c.get(locationIndex)) {
       this.mapState_800c6798.submapCut_c4 = 13; // Hellena
       this.mapState_800c6798.submapScene_c6 = 17;
       locationIndex = 5;
@@ -4725,20 +4730,20 @@ public class WMap extends EngineState {
     this.mapState_800c6798.locationCount_08 = locations_800f0e34.length;
 
     //LAB_800e7d1c
-    int sp24;
-    for(sp24 = 0; directionalPathSegmentData_800f2248.get(sp24).pathSegmentIndexAndDirection_00.get() != 0; sp24++) {
+    int directionalPathSegmentIndex;
+    for(directionalPathSegmentIndex = 0; directionalPathSegmentData_800f2248.get(directionalPathSegmentIndex).pathSegmentIndexAndDirection_00.get() != 0; directionalPathSegmentIndex++) {
       // intentionally empty
     }
 
     //LAB_800e7d64
-    this.mapState_800c6798.directionalPathCount_0c = sp24;
+    this.mapState_800c6798.directionalPathCount_0c = directionalPathSegmentIndex;
 
     GsInitCoordinate2(null, this.wmapStruct258_800c66a8.coord2_34);
 
     this.mapState_800c6798.continent_00 = locations_800f0e34[locationIndex].continent_0e;
     continentIndex_800bf0b0.set(this.mapState_800c6798.continent_00.ordinal());
 
-    this.FUN_800ea630(locationIndex);
+    this.setNewPathSegmentStateInfo(locationIndex);
 
     this.mapState_800c6798.queenFuryForceMovementState_d8 = ForcedMovementState.NONE;
 
@@ -4773,7 +4778,7 @@ public class WMap extends EngineState {
 
         if(directionalPathIndex != -1) {
           //LAB_800e7f68
-          if(this.FUN_800eb09c(i, -1, null) == 0) {
+          if(this.checkLocationIsValidAndOptionallySetPathStart(i, -1, null) == 0) {
             //LAB_800e7f88
             if(directionalPathIndex == this.mapState_800c6798.directionalPathIndex_12) {
               locationIndex = i;
@@ -5215,7 +5220,7 @@ public class WMap extends EngineState {
     for(int i = 0; i < this.mapState_800c6798.locationCount_08; i++) {
       //LAB_800e9888
       // Seems like it's mostly used here to check continent number?
-      if(this.FUN_800eb09c(i, 0, null) == 0) {
+      if(this.checkLocationIsValidAndOptionallySetPathStart(i, 0, null) == 0) {
         //LAB_800e98a8
         if(locations_800f0e34[i]._0c != -1) {
           //LAB_800e98e0
@@ -5342,7 +5347,7 @@ public class WMap extends EngineState {
     //LAB_800ea174
     this.mapState_800c6798.pathSegmentEndpointTypeCrossed_fc = PathSegmentEndpointType.NOT_AT_ENDPOINT;
 
-    this.FUN_800ea4dc(this.mapState_800c6798.tempPathSegmentIndices_dc[newPathIndex]);
+    this.identifyNewPathSegmentAndSetStateInfo(this.mapState_800c6798.tempPathSegmentIndices_dc[newPathIndex]);
 
     final DirectionalPathSegmentData08 directionalPathSegment = directionalPathSegmentData_800f2248.get(this.mapState_800c6798.directionalPathIndex_12);
 
@@ -5394,7 +5399,7 @@ public class WMap extends EngineState {
   }
 
   @Method(0x800ea4dcL)
-  private void FUN_800ea4dc(final int directionalPathIndex) {
+  private void identifyNewPathSegmentAndSetStateInfo(final int directionalPathIndex) {
     this.mapState_800c6798.directionalPathIndex_12 = directionalPathIndex;
 
     //LAB_800ea4fc
@@ -5403,13 +5408,11 @@ public class WMap extends EngineState {
       //LAB_800ea520
       if(locations_800f0e34[i].directionalPathIndex_00 != -1) {
         //LAB_800ea558
-        if(this.FUN_800eb09c(i, 0, null) == 0) {
+        if(this.checkLocationIsValidAndOptionallySetPathStart(i, 0, null) == 0) {
           //LAB_800ea578
-          if(locations_800f0e34[i].continent_0e == this.mapState_800c6798.continent_00) {
-            //LAB_800ea5bc
-            if(locations_800f0e34[i].directionalPathIndex_00 == directionalPathIndex) {
-              break;
-            }
+          //LAB_800ea5bc
+          if(locations_800f0e34[i].directionalPathIndex_00 == directionalPathIndex) {
+            break;
           }
         }
       }
@@ -5417,11 +5420,12 @@ public class WMap extends EngineState {
     }
 
     //LAB_800ea610
-    this.FUN_800ea630(i);
+    this.setNewPathSegmentStateInfo(i);
   }
 
+  /** Sets relevant state fields for the path segment the player is either loading into or entering. */
   @Method(0x800ea630L)
-  private void FUN_800ea630(final int locationIndex) {
+  private void setNewPathSegmentStateInfo(final int locationIndex) {
     if(locations_800f0e34[locationIndex].directionalPathIndex_00 == -1) {
       return;
     }
@@ -5432,7 +5436,7 @@ public class WMap extends EngineState {
     }
 
     //LAB_800ea6bc
-    if(this.FUN_800eb09c(locationIndex, 0, null) != 0) {
+    if(this.checkLocationIsValidAndOptionallySetPathStart(locationIndex, 0, null) != 0) {
       return;
     }
 
@@ -5484,18 +5488,10 @@ public class WMap extends EngineState {
   }
 
   @Method(0x800eab94L)
-  private void FUN_800eab94(final int locationIndex) {
-    if(locations_800f0e34[locationIndex].directionalPathIndex_00 == -1) {
-      return;
-    }
-
+  private void initDataForReversePath(final int locationIndex) {
     //LAB_800eabdc
-    if(locations_800f0e34[locationIndex].continent_0e != this.mapState_800c6798.continent_00) {
-      return;
-    }
-
     //LAB_800eac20
-    if(this.FUN_800eb09c(locationIndex, 0, null) != 0) {
+    if(this.checkLocationIsValidAndOptionallySetPathStart(locationIndex, 0, null) != 0) {
       return;
     }
 
@@ -5538,16 +5534,24 @@ public class WMap extends EngineState {
   }
 
   /**
-   * a1 used to be either 0, -1, or a VECTOR. If passing a VECTOR, pass it as dotPos and set a1 to 1
+   * Mode used to be either 0, -1, or a VECTOR. If passing a VECTOR, pass it as dotPos and set mode to 1
+   * @return state
+   * <ol start="-3">
+   *   <li>Path not found</li>
+   *   <li>Location not on current continent</li>
+   *   <li>Location does not exist</li>
+   *   <li>Location and path valid</li>
+   *   <li>Destination flags for location not set on gameState</li>
+   * </ol>
    */
   @Method(0x800eb09cL)
-  private int FUN_800eb09c(final int locationIndex, final int a1, @Nullable final Vector3f dotPos) {
+  private int checkLocationIsValidAndOptionallySetPathStart(final int locationIndex, final int mode, @Nullable final Vector3f dotPos) {
     if(locations_800f0e34[locationIndex].directionalPathIndex_00 == -1) {
       return -1;
     }
 
     //LAB_800eb0ec
-    if(a1 != -1) {
+    if(mode != -1) {
       if(locations_800f0e34[locationIndex].continent_0e != this.mapState_800c6798.continent_00) {
         return -2;
       }
@@ -5559,7 +5563,7 @@ public class WMap extends EngineState {
     }
 
     //LAB_800eb1d0
-    if(a1 == 0 || a1 == -1) {
+    if(mode == 0 || mode == -1) {
       //LAB_800eb1f8
       return 0;
     }
@@ -5607,7 +5611,7 @@ public class WMap extends EngineState {
     //LAB_800eb424
     for(int i = 0; i < this.mapState_800c6798.locationCount_08; i++) {
       //LAB_800eb448
-      if(this.FUN_800eb09c(i, 0, null) == 0) {
+      if(this.checkLocationIsValidAndOptionallySetPathStart(i, 0, null) == 0) {
         //LAB_800eb468
         if(!sp0xd0[i]) {
           //LAB_800eb48c
@@ -5617,7 +5621,7 @@ public class WMap extends EngineState {
           //LAB_800eb4c8
           for(int sp1c = i; sp1c < this.mapState_800c6798.locationCount_08; sp1c++) {
             //LAB_800eb4ec
-            if(this.FUN_800eb09c(sp1c, 0, null) == 0) {
+            if(this.checkLocationIsValidAndOptionallySetPathStart(sp1c, 0, null) == 0) {
               //LAB_800eb50c
               if(!sp0xd0[sp1c]) {
                 //LAB_800eb530
@@ -5628,7 +5632,7 @@ public class WMap extends EngineState {
                   if(!places_800f0234.get(placeIndex0).name_00.isNull() && !places_800f0234.get(placeIndex1).name_00.isNull()) {
                     //LAB_800eb5d8
                     if(strcmp(places_800f0234.get(placeIndex0).name_00.deref().get(), places_800f0234.get(placeIndex1).name_00.deref().get()) == 0) {
-                      this.FUN_800eb09c(sp1c, 1, sp0x60[sp20]);
+                      this.checkLocationIsValidAndOptionallySetPathStart(sp1c, 1, sp0x60[sp20]);
 
                       sp20++;
                       sp0xd0[sp1c] = true;

--- a/src/main/java/legend/game/wmap/WMapStruct258.java
+++ b/src/main/java/legend/game/wmap/WMapStruct258.java
@@ -21,7 +21,7 @@ public class WMapStruct258 {
     END_FADE
   }
 
-  public enum MapTransitionDestinationMode {
+  public enum MapTransitionDestinationType {
     NONE,
     TELEPORT,
     SUBMAP,
@@ -157,7 +157,7 @@ public class WMapStruct258 {
    *   <li>Transition to world map</li>
    * </ol>
    */
-  public MapTransitionDestinationMode mapTransitionDestinationMode_250;
+  public MapTransitionDestinationType mapTransitionDestinationType_250;
   public boolean usingCoolonFromZenebatos_254;
 
   public void deleteAtmosphericEffectObjs() {

--- a/src/main/java/legend/game/wmap/WMapStruct258.java
+++ b/src/main/java/legend/game/wmap/WMapStruct258.java
@@ -9,11 +9,18 @@ import legend.game.unpacker.FileData;
 import org.joml.Vector3f;
 
 public class WMapStruct258 {
-  public enum WmapActiveState {
-    ACTIVE,
-    TRANSITION_IN,
-    TRANSITION_OUT
+  public enum TransitionAnimationType {
+    NONE,
+    FADE_IN,
+    FADE_OUT
   }
+
+  public enum FadeState {
+    START_FADE,
+    FADE,
+    END_FADE
+  }
+
   public enum MapTransitionAnimationMode {
     NO_ANIMATION,
     TELEPORT,
@@ -21,19 +28,33 @@ public class WMapStruct258 {
     WORLD_MAP
   }
 
-  public int _00;
-  /** ubyte */
-  public int _04;
-  /** ubyte */
-  public WmapActiveState wmapState_05;
+  public int transitionAnimationTicks_00;
+  /**
+   * ubyte
+   * <ol start="0">
+   *  <li>Start fade</li>
+   *  <li>Fade</li>
+   *  <li>End fade</li>
+   * </ol>
+   */
+  public FadeState fadeState_04;
+  /**
+   * ubyte
+   * <ol start="0">
+   *  <li>None</li>
+   *  <li>Fade in</li>
+   *  <li>Fade out</li>
+   * </ol>
+   */
+  public TransitionAnimationType transitionAnimationType_05;
 
   public WMapTmdRenderingStruct18 tmdRendering_08;
   public final Model124[] models_0c = new Model124[4];
   public TextureAnimation20 textureAnimation_1c;
-  /** short */
-  public float colour_20;
+  /** Used for brightness of the map name and the map textures overall (short) */
+  public float mapTextureBrightness_20;
 
-  public MeshObj mapOverlayObj;
+  public MeshObj mapContinentNameObj;
   public MeshObj[] zoomOverlayObjs = new MeshObj[7];
   public final MV mapOverlayTransforms = new MV();
 

--- a/src/main/java/legend/game/wmap/WMapStruct258.java
+++ b/src/main/java/legend/game/wmap/WMapStruct258.java
@@ -93,14 +93,18 @@ public class WMapStruct258 {
   public Obj shadowObj;
   public final MV shadowTransforms = new MV();
   public int modelIndex_1e4;
-  public final Vector3f svec_1e8 = new Vector3f();
-  public final Vector3f svec_1f0 = new Vector3f();
+
+  // Zoom attributes
+  public final Vector3f mapPosition_1e8 = new Vector3f();
+  public final Vector3f mapZoomStep_1f0 = new Vector3f();
   /** ubyte */
   public int zoomState_1f8;
   /** Not in retail */
   public int previousZoomLevel;
   /** ubyte */
   public int zoomAnimationTick_1f9;
+
+  // Coolon attributes
   /** Highlight refactored into WmapPromptPopup */
   // public WmapMenuTextHighlight40 coolonTravelMenuSelectorHighlight_1fc;
   public final Vector3f svec_200 = new Vector3f();
@@ -118,7 +122,7 @@ public class WMapStruct258 {
   /** ubyte */
   public int coolonWarpIndex_222;
   /** ubyte */
-  public int _223;
+  public int coolonPromptIndex_223;
 
 
   // _224 through _248 are used for rendering the Queen Fury's wake, though they are

--- a/src/main/java/legend/game/wmap/WMapStruct258.java
+++ b/src/main/java/legend/game/wmap/WMapStruct258.java
@@ -28,6 +28,20 @@ public class WMapStruct258 {
     WORLD_MAP
   }
 
+  /**
+   * TODO Look more into zoom code before refactoring to use states, might be able
+   *  to reduce number.
+   */
+  public enum ZoomState {
+    LOCAL,
+    CONTINENT_IN,
+    TRANSITION_MODEL_OUT,
+    TRANSITION_ARROW_SIZE,
+    WORLD,
+    TRANSITION_MODEL_IN,
+    CONTINENT_OUT
+  }
+
   public int transitionAnimationTicks_00;
   /**
    * ubyte
@@ -86,7 +100,7 @@ public class WMapStruct258 {
   /** Not in retail */
   public int previousZoomLevel;
   /** ubyte */
-  public int _1f9;
+  public int zoomAnimationTick_1f9;
   /** Highlight refactored into WmapPromptPopup */
   // public WmapMenuTextHighlight40 coolonTravelMenuSelectorHighlight_1fc;
   public final Vector3f svec_200 = new Vector3f();

--- a/src/main/java/legend/game/wmap/WMapStruct258.java
+++ b/src/main/java/legend/game/wmap/WMapStruct258.java
@@ -21,8 +21,8 @@ public class WMapStruct258 {
     END_FADE
   }
 
-  public enum MapTransitionAnimationMode {
-    NO_ANIMATION,
+  public enum MapTransitionDestinationMode {
+    NONE,
     TELEPORT,
     SUBMAP,
     WORLD_MAP
@@ -132,7 +132,7 @@ public class WMapStruct258 {
    *   <li>Transition to world map</li>
    * </ol>
    */
-  public MapTransitionAnimationMode mapTransitionAnimationMode_250;
+  public MapTransitionDestinationMode mapTransitionDestinationMode_250;
   public boolean usingCoolonFromZenebatos_254;
 
   public void deleteAtmosphericEffectObjs() {

--- a/src/main/java/legend/game/wmap/WMapStruct258.java
+++ b/src/main/java/legend/game/wmap/WMapStruct258.java
@@ -42,6 +42,13 @@ public class WMapStruct258 {
     CONTINENT_OUT
   }
 
+  public enum TeleportAnimationState {
+    INIT_ANIM,
+    RENDER_ANIM,
+    INIT_FADE,
+    FADE_OUT
+  }
+
   public int transitionAnimationTicks_00;
   /**
    * ubyte
@@ -125,7 +132,7 @@ public class WMapStruct258 {
   public int coolonPromptIndex_223;
 
 
-  // _224 through _248 are used for rendering the Queen Fury's wake, though they are
+  // _224 through _244 are used for rendering the Queen Fury's wake, though they are
   // initialized regardless.
   public Vector3f[] wakeSpreadsArray_224;
   public Vector3f[] shipPositionsArray_228;
@@ -137,9 +144,9 @@ public class WMapStruct258 {
   public int tickNum_240;
   /** byte */
   public boolean shipPositionsUninitialized_244;
-  public int _248;
+  public TeleportAnimationState teleportAnimationState_248;
 
-  public int _24c;
+  public int teleportAnimationTick_24c;
   /**
    * Not totally sure what this should be called yet, but seems related to transitions
    * and transition animations (except combat).

--- a/src/main/java/legend/game/wmap/WmapStatics.java
+++ b/src/main/java/legend/game/wmap/WmapStatics.java
@@ -89,7 +89,7 @@ public final class WmapStatics {
 
   public static final UnboundedArrayRef<Place0c> places_800f0234 = MEMORY.ref(4, 0x800f0234L, UnboundedArrayRef.of(0xc, Place0c::new));
 
-  /** Valid entries seem to end at 158, though their seem to be some 0 entries scattered throughout as well */
+  /** Valid entries seem to end at 158, though there seem to be some 0 entries scattered throughout as well */
   public static final Location14[] locations_800f0e34 = {
     new Location14(4, 0, 7, 13, 7, 12, 0, Continent.SOUTH_SERDIO, true, 128),
     new Location14(3, 1, 624, 11, 624, 10, 1, Continent.SOUTH_SERDIO, false, 128),


### PR DESCRIPTION
More names, more enums, more switch refactors. Removed what should be some redundant checks from certain condition chains.

Fixed several things that were messing up the teleportation animations. Now works properly at 60fps with floats.

It's *nearly* the same as retail now minus the screen distortion effect, but I'm just going to wait for that to be implementable to do a final comparison and see if anything actually needs fixing, or if it's the lack of distortion making it seem different.

Closes #887