### PR TITLE
Fixes WMAP snow animation

### DIFF
--- a/src/main/java/legend/game/wmap/WMap.java
+++ b/src/main/java/legend/game/wmap/WMap.java
@@ -5627,7 +5627,7 @@ public class WMap extends EngineState {
       }
 
       //LAB_800ebe24
-      cloud.snowUvIndex_50 = 0;
+      cloud.snowTick_50 = 0;
       cloud.translation_58.set((288 - rand() % 64) / 2, (80 - rand() % 32) / 2, 0);
       cloud.brightness_5c = 0.0f;
     }
@@ -5784,7 +5784,7 @@ public class WMap extends EngineState {
       snowflake.coord2_00.coord.transfer.x = 500 - rand() % 1000;
       snowflake.coord2_00.coord.transfer.y =     - rand() %  200;
       snowflake.coord2_00.coord.transfer.z = 500 - rand() % 1000;
-      snowflake.snowUvIndex_50 = rand() % 12;
+      snowflake.snowTick_50 = rand() % 12;
       snowflake.translation_58.set(rand() % 2 - 1, rand() % 2 + 1, rand() % 2 - 1);
       snowflake.brightness_5c = 0.0f;
     }
@@ -5877,8 +5877,9 @@ public class WMap extends EngineState {
                 //LAB_800ed570
                 //LAB_800ed5a4
                 //LAB_800ed5d8
-                snowflake.snowUvIndex_50 = (snowflake.snowUvIndex_50 + 1) % 12;
-                final int index = (int)(snowflake.snowUvIndex_50 / 2.0f);
+                snowflake.snowTick_50 = (snowflake.snowTick_50 + 1.0f / (3.0f / vsyncMode_8007a3b8)) % 12;
+                final int index = (int)(snowflake.snowTick_50 / 2.0f);
+                snowflake.transforms.scaling(sx1 - sx0, sy2 - sy0, 1.0f);
                 snowflake.transforms.transfer.set(GPU.getOffsetX() + sx0, GPU.getOffsetY() + sy0, 556.0f);
                 RENDERER.queueOrthoModel(modelAndAnimData.atmosphericEffectSprites[index], snowflake.transforms)
                   .monochrome(snowflake.brightness_5c);

--- a/src/main/java/legend/game/wmap/WMapAtmosphericEffectInstance60.java
+++ b/src/main/java/legend/game/wmap/WMapAtmosphericEffectInstance60.java
@@ -17,7 +17,7 @@ public class WMapAtmosphericEffectInstance60 {
 
   public final GsCOORDINATE2 coord2_00 = new GsCOORDINATE2();
   /** Originally vector rotation_50 */
-  public int snowUvIndex_50;
+  public float snowTick_50;
   /** Was short x_58, short y_5a, byte z_5e */
   public final Vector3i translation_58 = new Vector3i();
   /** short */
@@ -25,7 +25,7 @@ public class WMapAtmosphericEffectInstance60 {
 
   public void set(final WMapAtmosphericEffectInstance60 other) {
     this.coord2_00.set(other.coord2_00);
-    this.snowUvIndex_50 = other.snowUvIndex_50;
+    this.snowTick_50 = other.snowTick_50;
     this.translation_58.set(other.translation_58);
     this.brightness_5c = other.brightness_5c;
   }
@@ -54,10 +54,11 @@ public class WMapAtmosphericEffectInstance60 {
         .bpp(Bpp.BITS_4)
         .clut(640, 496)
         .vramPos(640, 256)
-        .size(2.0f, 2.0f)
+        .size(1.0f, 1.0f)
         .uv(WMapAtmosphericEffectInstance60.snowUs[i], WMapAtmosphericEffectInstance60.snowVs[i])
         .uvSize(8, 8)
         .translucency(Translucency.B_PLUS_F)
+        .monochrome(1.0f)
         .build();
     }
 


### PR DESCRIPTION
Speed of UV cycling was to fast, snowflakes weren't bright enough, and snowflakes weren't scaling. This should fix all of those.

Closes #910 