### PR TITLE
Make debugger spawn child windows centered to itself

### DIFF
--- a/src/main/java/legend/game/debugger/CombatDebugger.java
+++ b/src/main/java/legend/game/debugger/CombatDebugger.java
@@ -15,6 +15,8 @@ public class CombatDebugger extends Application {
 
     stage.setTitle("Combat Debugger");
     stage.setScene(scene);
+    stage.setX(Debugger.getStage().getX() + ((Debugger.getStage().getWidth() - root.prefWidth(-1)) / 2));
+    stage.setY(Debugger.getStage().getY() + ((Debugger.getStage().getHeight() - root.prefHeight(-1)) / 2));
     stage.show();
   }
 }

--- a/src/main/java/legend/game/debugger/Debugger.java
+++ b/src/main/java/legend/game/debugger/Debugger.java
@@ -32,4 +32,8 @@ public class Debugger extends Application {
     stage.show();
     Debugger.stage = stage;
   }
+
+  public static Stage getStage() {
+    return Debugger.stage;
+  }
 }

--- a/src/main/java/legend/game/debugger/GameStateEditor.java
+++ b/src/main/java/legend/game/debugger/GameStateEditor.java
@@ -29,6 +29,8 @@ public class GameStateEditor extends Application {
 
     stage.setTitle("GameState Editor");
     stage.setScene(scene);
+    stage.setX(Debugger.getStage().getX() + ((Debugger.getStage().getWidth() - root.prefWidth(-1)) / 2));
+    stage.setY(Debugger.getStage().getY() + (Debugger.getStage().getHeight() / 8));
     stage.show();
     GameStateEditor.stage = stage;
   }

--- a/src/main/java/legend/game/debugger/GameStateViewer.java
+++ b/src/main/java/legend/game/debugger/GameStateViewer.java
@@ -29,6 +29,8 @@ public class GameStateViewer extends Application {
 
     stage.setTitle("GameState Viewer");
     stage.setScene(scene);
+    stage.setX(Debugger.getStage().getX() + ((Debugger.getStage().getWidth() - root.prefWidth(-1)) / 2));
+    stage.setY(Debugger.getStage().getY() + (Debugger.getStage().getHeight()  / 8));
     stage.show();
     GameStateViewer.stage = stage;
   }

--- a/src/main/java/legend/game/debugger/ScriptDebugger.java
+++ b/src/main/java/legend/game/debugger/ScriptDebugger.java
@@ -28,6 +28,8 @@ public class ScriptDebugger extends Application {
 
     stage.setTitle("Script Debugger");
     stage.setScene(scene);
+    stage.setX(Debugger.getStage().getX() + ((Debugger.getStage().getWidth() - root.prefWidth(-1)) / 2));
+    stage.setY(Debugger.getStage().getY() + ((Debugger.getStage().getHeight() - root.prefHeight(-1)) / 2));
     stage.show();
   }
 

--- a/src/main/java/legend/game/debugger/SmapDebugger.java
+++ b/src/main/java/legend/game/debugger/SmapDebugger.java
@@ -15,6 +15,8 @@ public class SmapDebugger extends Application {
 
     stage.setTitle("Submap Debugger");
     stage.setScene(scene);
+    stage.setX(Debugger.getStage().getX() + ((Debugger.getStage().getWidth() - root.prefWidth(-1)) / 2));
+    stage.setY(Debugger.getStage().getY() + ((Debugger.getStage().getHeight() - root.prefHeight(-1)) / 2));
     stage.show();
   }
 }

--- a/src/main/resources/legend/game/debugger/gamestate_editor.fxml
+++ b/src/main/resources/legend/game/debugger/gamestate_editor.fxml
@@ -9,7 +9,7 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox prefHeight="400.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="legend.game.debugger.GameStateEditorController">
+<VBox prefHeight="675.0" prefWidth="840.0" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="legend.game.debugger.GameStateEditorController">
     <AnchorPane VBox.vgrow="ALWAYS">
         <HBox prefHeight="400.0" prefWidth="200.0">
             <VBox>

--- a/src/main/resources/legend/game/debugger/gamestate_viewer.fxml
+++ b/src/main/resources/legend/game/debugger/gamestate_viewer.fxml
@@ -5,7 +5,7 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox prefHeight="400.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="legend.game.debugger.GameStateViewerController">
+<VBox prefHeight="800.0" prefWidth="1240.0" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="legend.game.debugger.GameStateViewerController">
     <AnchorPane VBox.vgrow="ALWAYS">
         <HBox prefHeight="400.0" prefWidth="150.0">
             <VBox>


### PR DESCRIPTION
- Reduce need to drag and manage debugger windows around
- Updated some of the prefHeights and prefWidths to match the layouts

**Motivation**

- Testing the game and wasting too much time moving windows