### PR TITLE
remove unused DEFF obj allocation

### DIFF
--- a/src/main/java/legend/game/combat/Battle.java
+++ b/src/main/java/legend/game/combat/Battle.java
@@ -6505,9 +6505,6 @@ public class Battle extends EngineState {
 
   @Method(0x800e8ffcL)
   public void allocateDeffManager() {
-    if(deffManager_800c693c != null) {
-      deffManager_800c693c.delete();
-    }
 
     final DeffManager7cc deffManager = new DeffManager7cc();
     this.loadedDeff_800c6938 = deffManager._5b8;
@@ -6527,7 +6524,6 @@ public class Battle extends EngineState {
     scriptStatePtrArr_800bc1c0[1].deallocateWithChildren();
     deffManager_800c693c.deallocateScriptsArray();
     deffManager_800c693c.scriptState_1c.deallocateWithChildren();
-    deffManager_800c693c.delete();
     deffManager_800c693c = null;
   }
 
@@ -6981,7 +6977,6 @@ public class Battle extends EngineState {
       if(index >= 5) {
         final DeffPart.TmdType tmdType = new DeffPart.TmdType("HUD DEFF file " + i, files.get(i));
         struct7cc.tmds_2f8[index] = tmdType.tmd_0c.tmdPtr_00.tmd.objTable[0];
-        struct7cc.objs[index] = TmdObjLoader.fromObjTable(tmdType.name, struct7cc.tmds_2f8[index]);
       }
 
       //LAB_800ea928

--- a/src/main/java/legend/game/combat/deff/DeffManager7cc.java
+++ b/src/main/java/legend/game/combat/deff/DeffManager7cc.java
@@ -43,7 +43,6 @@ public class DeffManager7cc {
   public final StageAmbiance4c[] dragoonSpaceAmbiance_98 = {new StageAmbiance4c(), new StageAmbiance4c(), new StageAmbiance4c(), new StageAmbiance4c(), new StageAmbiance4c(), new StageAmbiance4c(), new StageAmbiance4c(), new StageAmbiance4c()};
   /** Only type 3 TMDs (see {@link DeffPart#flags_00}) */
   public final TmdObjTable1c[] tmds_2f8 = new TmdObjTable1c[38];
-  public final Obj[] objs = new Obj[38];
   public final DeffPart.LmbType[] lmbs_390 = new DeffPart.LmbType[3];
   public final SpriteMetrics08[] spriteMetrics_39c = new SpriteMetrics08[65];
   public DeffPart[] deffPackage_5a8;
@@ -55,15 +54,6 @@ public class DeffManager7cc {
 
   public DeffManager7cc() {
     Arrays.setAll(this.spriteMetrics_39c, i -> new SpriteMetrics08());
-  }
-
-  public void delete() {
-    for(int i = 0; i < this.objs.length; i++) {
-      if(this.objs[i] != null) {
-        this.objs[i].delete();
-        this.objs[i] = null;
-      }
-    }
   }
 
   @Method(0x800eab8cL)


### PR DESCRIPTION
removes unnecessary OpenGL object Allocation and caching in DeffManager7cc.objs array that, these were not actually in use, the TMD data is still retained as needed. However, the pre-allocated Obj instances were redundant as they are created on demand, when they are actually needed.

Changes:
-Removed unused objs array from Deffmanager7cc
-Removed delete() method that only cleaned up unused objs
 -Removed TmdObjLoade.fromObj.Table()allocation within Batlle.hudDeffLoaded() 
-Removed delete() calls in Battle that are not needed -Removed if null check that used delete() call

Fixes Legend-of-Dragoon-Modding/Severed-Chains#1037