### PR TITLE
add WorldmapGenerateEncounterEvent

### DIFF
--- a/src/main/java/legend/game/modding/events/worldmap/WorldmapEvent.java
+++ b/src/main/java/legend/game/modding/events/worldmap/WorldmapEvent.java
@@ -1,0 +1,6 @@
+package legend.game.modding.events.worldmap;
+
+import org.legendofdragoon.modloader.events.Event;
+
+public class WorldmapEvent extends Event {
+}

--- a/src/main/java/legend/game/modding/events/worldmap/WorldmapGenerateEncounterEvent.java
+++ b/src/main/java/legend/game/modding/events/worldmap/WorldmapGenerateEncounterEvent.java
@@ -1,0 +1,15 @@
+package legend.game.modding.events.worldmap;
+
+import legend.game.wmap.DirectionalPathSegmentData08;
+
+public class WorldmapGenerateEncounterEvent extends WorldmapEvent{
+  public int encounterId;
+  public int battleStageId;
+  final public DirectionalPathSegmentData08 directionalPathSegment;
+
+  public WorldmapGenerateEncounterEvent(final int encounterId, final int battleStageId, final DirectionalPathSegmentData08 directionalPathSegment) {
+    this.encounterId = encounterId;
+    this.battleStageId = battleStageId;
+    this.directionalPathSegment = directionalPathSegment;
+  }
+}

--- a/src/main/java/legend/game/wmap/WMap.java
+++ b/src/main/java/legend/game/wmap/WMap.java
@@ -21,6 +21,7 @@ import legend.game.EngineState;
 import legend.game.EngineStateEnum;
 import legend.game.inventory.WhichMenu;
 import legend.game.modding.coremod.CoreMod;
+import legend.game.modding.events.worldmap.WorldmapGenerateEncounterEvent;
 import legend.game.submap.EncounterRateMode;
 import legend.game.tim.Tim;
 import legend.game.tmd.TmdObjLoader;
@@ -55,6 +56,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static legend.core.GameEngine.CONFIG;
 import static legend.core.GameEngine.DISCORD;
+import static legend.core.GameEngine.EVENTS;
 import static legend.core.GameEngine.GPU;
 import static legend.core.GameEngine.GTE;
 import static legend.core.GameEngine.PLATFORM;
@@ -3668,13 +3670,8 @@ public class WMap extends EngineState {
     if(this.encounterAccumulator_800c6ae8 >= 5120) {
       this.encounterAccumulator_800c6ae8 = 0;
 
-      final int stageId;
-      if(directionalPathSegment.battleStage_04 == -1) {
-        stageId = 1;
-      } else {
-        //LAB_800e386c
-        stageId = directionalPathSegment.battleStage_04;
-      }
+      //LAB_800e386c
+      final var battleStageId = directionalPathSegment.battleStage_04 == -1 ? 1 : directionalPathSegment.battleStage_04;
 
       //LAB_800e3894
       final int encounterIndex = directionalPathSegment.encounterIndex_05;
@@ -3699,7 +3696,8 @@ public class WMap extends EngineState {
         }
       }
 
-      startLegacyEncounter(encounterId, stageId);
+      final var generateEncounterEvent = EVENTS.postEvent(new WorldmapGenerateEncounterEvent(encounterId, battleStageId, directionalPathSegment));
+      startLegacyEncounter(generateEncounterEvent.encounterId, generateEncounterEvent.battleStageId);
 
       //LAB_800e3a38
       gameState_800babc8.directionalPathIndex_4de = this.mapState_800c6798.directionalPathIndex_12;


### PR DESCRIPTION
**Assertions**
- Wmap stuff is a distinct case, and has different behaviours than Smap
- Even if Wmap became an extension of a more generic Smap/Wmap implementation it would still be an extension
- Encounter data on Wmap is prepared somewhat differently to Submaps
- Both use startLegacyEncounter in Sbtld

**Source Dictated Influences**
Whatever happens with Wmap and Smap (generic shared implementation, more split) the two events are likely needed. 
- Submap encounters may want scene and cut information to influence the encounters
- Wmap encounters don't care for that, but for the direction index metadata
- There is no nice way to encapsulate these different sources into a singular encounter event

So this event for wmap is stating that encounters initiated on Wmap are different to encounters on Smap. And that the source is the main reason to have two separate events.

**Future Refactors**
I don't think either of these two events will change in the future.
- Smap and Wmap might change or become extensions of some more generic implementation
- startLegacyEncounter may gain an actual EncounterStartEncounterEvent for a more generic Encounter experience without duplicate code in wmap and smap and/or Sbtld is deleted and its highly varied implementations are extracted to more concise classes
- BUT some version or type of wmap and smap will exist and these two current events are going to be coupled to whatever it means to be a wmap or smap and what it means to start an encounter from these sources



