### PR TITLE
Fix for menu addition values (closes #2659)

### DIFF
--- a/src/main/java/legend/game/additions/SimpleAddition.java
+++ b/src/main/java/legend/game/additions/SimpleAddition.java
@@ -18,10 +18,10 @@ public abstract class SimpleAddition extends Addition {
     float damage = 0;
 
     for(int hit = 0; hit < this.hits.length; hit++) {
-      damage += this.hits[hit].damageMultiplier_04 * multi;
+      damage += this.hits[hit].damageMultiplier_04;
     }
 
-    return (int)damage;
+    return (int)(damage * multi);
   }
 
   @Override

--- a/src/main/java/legend/game/additions/SimpleAddition.java
+++ b/src/main/java/legend/game/additions/SimpleAddition.java
@@ -15,7 +15,7 @@ public abstract class SimpleAddition extends Addition {
   @Override
   public int getDamage(final GameState52c state, final CharacterData2c charData, final CharacterAdditionStats additionStats) {
     final float multi = this.getDamageMultiplier(state, charData, additionStats);
-    float damage = 0;
+    int damage = 0;
 
     for(int hit = 0; hit < this.hits.length; hit++) {
       damage += this.hits[hit].damageMultiplier_04;


### PR DESCRIPTION
The issue is caused by float math.
There are multiple += hit * multi, since the value is floored at the end, this compounds the float imprecision enough to shift it slightly below the actual value.